### PR TITLE
fix: preserve escapes and translate multi-line entries

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,16 +24,20 @@ const SUPPORTED_LANGUAGES = [
 	"yi", "yo", "zh", "zu"
 ];
 
-// Delimiter used to separate segments in multi-line properties
-const SEGMENT_DELIMITER = "\u241E";
+// Delimiter used to separate segments in multi-line properties.
+// Must be plain ASCII: the translation model silently drops non-ASCII characters
+// (U+241E was dropped every time), which broke segment splitting and caused
+// correctly translated multi-line entries to be discarded as failures.
+const SEGMENT_DELIMITER = "__SEG__";
 
 // Pattern to match placeholders in property values
 const PLACEHOLDER_REGEX = /\{[0-9a-zA-Z_,.#:\s]+\}|\$\{[0-9a-zA-Z_.:-]+\}|%[0-9]*\$?[-+#0-9.]*[a-zA-Z]/g;
 
 // Control characters are masked alongside placeholders because the translation
 // model normalizes whitespace: a raw \n or \t sent to it comes back as a space,
-// silently destroying the escape sequence in the output file.
-const CONTROL_CHAR_REGEX = /[\n\r\t\f]/g;
+// silently destroying the escape sequence in the output file. The full C0 range
+// and DEL are covered because \uXXXX escapes can decode to any of them.
+const CONTROL_CHAR_REGEX = /[\x00-\x1f\x7f]/g;
 
 // Structured logging helper for better observability
 function logError(event: string, details: Record<string, unknown>): void {
@@ -207,7 +211,10 @@ async function translateEntry(lines: string[], targetLanguage: string, env: Env)
 
 	const placeholderCounter = { current: 0 };
 	const maskedSegments = unescapedValues.map(value => maskPlaceholders(value, placeholderCounter));
-	const combinedValue = maskedSegments.map(segment => segment.text).join(SEGMENT_DELIMITER);
+	// A trailing space keeps the delimiter from fusing to the following word, which
+	// left that word untranslated. Continuation values already end with a space
+	// before their backslash, so the left-hand side needs no padding.
+	const combinedValue = maskedSegments.map(segment => segment.text).join(`${SEGMENT_DELIMITER} `);
 
 	try {
 		const translatedCombined = await translateText(combinedValue, targetLanguage, env);
@@ -218,7 +225,13 @@ async function translateEntry(lines: string[], targetLanguage: string, env: Env)
 		}
 
 		const translatedLines = segments.map((segment, idx) => {
-			const restoredPlaceholders = restorePlaceholders(translatedSegments[idx], maskedSegments[idx].tokens);
+			// Drop the padding space introduced by the join. Continuation values never
+			// begin with whitespace (parseContinuationLine moves it into the prefix),
+			// so any leading whitespace here is an artifact.
+			const translatedSegment = idx === 0
+				? translatedSegments[idx]
+				: translatedSegments[idx].replace(/^[ \t]+/, "");
+			const restoredPlaceholders = restorePlaceholders(translatedSegment, maskedSegments[idx].tokens);
 			const escapedValue = escapePropertiesText(restoredPlaceholders);
 			return `${segment.prefix}${escapedValue}${segment.suffix}`;
 		});

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,11 @@ const SEGMENT_DELIMITER = "\u241E";
 // Pattern to match placeholders in property values
 const PLACEHOLDER_REGEX = /\{[0-9a-zA-Z_,.#:\s]+\}|\$\{[0-9a-zA-Z_.:-]+\}|%[0-9]*\$?[-+#0-9.]*[a-zA-Z]/g;
 
+// Control characters are masked alongside placeholders because the translation
+// model normalizes whitespace: a raw \n or \t sent to it comes back as a space,
+// silently destroying the escape sequence in the output file.
+const CONTROL_CHAR_REGEX = /[\n\r\t\f]/g;
+
 // Structured logging helper for better observability
 function logError(event: string, details: Record<string, unknown>): void {
 	console.error(JSON.stringify({
@@ -533,11 +538,15 @@ function escapePropertiesText(value: string): string {
 
 function maskPlaceholders(value: string, counter: { current: number }): { text: string; tokens: PlaceholderToken[] } {
 	const tokens: PlaceholderToken[] = [];
-	const text = value.replace(PLACEHOLDER_REGEX, (match) => {
+	const mask = (match: string) => {
 		const marker = `__PH_${counter.current++}__`;
 		tokens.push({ marker, original: match });
 		return marker;
-	});
+	};
+
+	const text = value
+		.replace(PLACEHOLDER_REGEX, mask)
+		.replace(CONTROL_CHAR_REGEX, mask);
 
 	return { text, tokens };
 }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -186,7 +186,7 @@ describe('TranslateMessages Worker', () => {
 	it('handles multi-line entries using continuations', async () => {
 		const mockRun = vi.fn()
 			.mockResolvedValueOnce({ translated_text: 'ok' })
-			.mockResolvedValueOnce({ translated_text: 'Bonjour \u241EMonde' });
+			.mockResolvedValueOnce({ translated_text: 'Bonjour __SEG__Monde' });
 
 		const mockEnv = {
 			...env,
@@ -333,6 +333,49 @@ describe('TranslateMessages Worker', () => {
 		// No raw control character may reach the model; only the masked marker form.
 		const translated = mockRun.mock.calls.map(([, args]) => args.text);
 		expect(translated.some((text) => /[\n\t\r\f]/.test(text))).toBe(false);
+	});
+
+	it('translates multi-line continuation entries when the model drops non-ASCII', async () => {
+		// The real m2m100 model silently drops non-ASCII characters such as U+241E.
+		// That destroyed segment splitting, so a correctly translated multi-line
+		// entry was discarded and fell back to the untranslated original.
+		const mockRun = vi.fn().mockImplementation((_model, args) =>
+			Promise.resolve({ translated_text: args.text.replace(/[^\x00-\x7F]/g, '').toUpperCase() })
+		);
+
+		const mockEnv = {
+			...env,
+			AI: { run: mockRun }
+		};
+
+		const fileContent = "multi=first part \\\n    second part \\\n    third part\n";
+		const formData = new FormData();
+		const file = new File([fileContent], 'messages.properties', { type: 'text/plain' });
+		formData.append('file', file);
+		formData.append('language', 'es');
+
+		const request = new IncomingRequest('http://example.com', {
+			method: 'POST',
+			body: formData
+		});
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, mockEnv, ctx);
+		await waitOnExecutionContext(ctx);
+
+		expect(response.status).toBe(200);
+		const body = await response.text();
+
+		// The uppercase marker proves the translation was kept rather than
+		// discarded via the failed-segment-count fallback.
+		expect(body).toContain('FIRST PART');
+		expect(body).toContain('SECOND PART');
+		expect(body).toContain('THIRD PART');
+		// Continuation structure must still be intact.
+		expect(body.split('\n').filter((l) => l.trim()).length).toBe(3);
+
+		// The delimiter itself must be ASCII so the model can round-trip it.
+		const sent = mockRun.mock.calls.map(([, args]) => args.text);
+		expect(sent.some((text) => /[^\x00-\x7F]/.test(text))).toBe(false);
 	});
 
 	it('handles empty files gracefully', async () => {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -299,6 +299,42 @@ describe('TranslateMessages Worker', () => {
 		expect(body).toBe("placeholder=Salut {0}\\! %s ${name}\n");
 	});
 
+	it('preserves \\n and \\t escapes when the model normalizes whitespace', async () => {
+		// The real m2m100 model collapses raw control characters to spaces, so any
+		// control character sent to it verbatim comes back destroyed. Simulate that.
+		const mockRun = vi.fn().mockImplementation((_model, args) =>
+			Promise.resolve({ translated_text: args.text.replace(/[\n\t\r\f]/g, ' ') })
+		);
+
+		const mockEnv = {
+			...env,
+			AI: { run: mockRun }
+		};
+
+		const fileContent = "message.escapes=First line\\nSecond line\\tTabbed value\n";
+		const formData = new FormData();
+		const file = new File([fileContent], 'messages.properties', { type: 'text/plain' });
+		formData.append('file', file);
+		formData.append('language', 'es');
+
+		const request = new IncomingRequest('http://example.com', {
+			method: 'POST',
+			body: formData
+		});
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, mockEnv, ctx);
+		await waitOnExecutionContext(ctx);
+
+		expect(response.status).toBe(200);
+		const body = await response.text();
+		expect(body).toContain('\\n');
+		expect(body).toContain('\\t');
+
+		// No raw control character may reach the model; only the masked marker form.
+		const translated = mockRun.mock.calls.map(([, args]) => args.text);
+		expect(translated.some((text) => /[\n\t\r\f]/.test(text))).toBe(false);
+	});
+
 	it('handles empty files gracefully', async () => {
 		const mockRun = vi.fn()
 			.mockResolvedValueOnce({ translated_text: 'ok' });


### PR DESCRIPTION
Fixes every translation-pipeline defect found by smoke-testing staging against the real m2m100 model.

## Shared root cause

**The model silently destroys characters it can't tokenize.** Both bugs came from sending it characters that never survive the round trip. Placeholders already worked precisely because they get masked into plain-ASCII `__PH_N__` markers first — that mechanism was the fix for both.

---

## Bug 1 — `\n` and `\t` were destroyed

```properties
# input
message.escapes=First line\nSecond line\tTabbed value

# before
message.escapes=Primera línea Segunda línea Valor tabulado
```

`unescapePropertiesText` converts `\n`/`\t` into **real control characters** before translation. Those went to the model verbatim, it normalized the whitespace to spaces, and `escapePropertiesText` had nothing left to re-escape. Any multi-line message value lost its line breaks.

An echo-mock test round-tripped perfectly, proving the pipeline was fine and the loss happened at the model boundary.

**Fix:** mask control characters alongside placeholders. Broadened to the full C0 range plus DEL, since `\uXXXX` escapes can decode to any control character and all are destroyed identically.

## Bug 2 — multi-line entries were never translated

The model was translating them **correctly**; we threw the result away. Captured at the boundary against the live model:

```
sent: "...continues ␞onto a second line and then wraps ␞onto a third line before ending."   (3 segments)
got:  "Esta es una frase larga que continúa en una segunda línea y luego envuelve..."
```

Every `␞` (U+241E) delimiter is gone. So `split` returned 1 segment instead of 3, the length check failed, and `translateEntry` discarded a good translation through the failed-segment fallback.

**Fix:** ASCII delimiter `__SEG__`, verified against the real model to survive exactly as `__PH_N__` does. Also padded with a trailing space so it doesn't fuse to the next word and leave it untranslated; the artifact is stripped after splitting. Stripping is safe because `parseContinuationLine` moves all leading whitespace into the prefix, so a continuation value never begins with whitespace.

---

## Why this wasn't caught

The existing multi-line test's mock **echoed the delimiter back faithfully** — something the real model never did. The test passed while production was broken. It's been updated, and a new test simulates the model dropping non-ASCII so this can't regress.

## Verification

Tests are written to fail against the old code and pass against the new, simulating real model behavior (whitespace normalization, non-ASCII dropping) rather than echoing input.

- **77/77 tests passing** (was 75)
- Both type checks clean
- Deployed to staging and verified end-to-end against the **real model**, not just mocks

Same input file that exposed all of this, now:

```properties
# Test file exercising the pipeline features added since the prod deploy
greeting.placeholder=Hola {0}, tienes {1} nuevos mensajes.
greeting.dollar=Bienvenido, ${userName}, tu cuenta está lista.
label.colon:Por favor introduzca su contraseña para continuar.
label.space  Este valor utiliza un separador de espacio blanco.
message.multiline=Esta es una frase larga que continúa \
    en una segunda línea y luego envuelve \
    en una tercera línea antes de terminar.
message.escapes=Primera línea\nSegunda línea\tValor tabulado
message.comment=Ahorre su trabajo antes de cerrar. # do not translate this marker
message.mixed=Usuario {0} cargó los archivos ${count} en %s ayer.
```

| | Before | After |
|---|---|---|
| `\n` / `\t` escapes | ❌ collapsed to spaces | ✅ preserved |
| Multi-line continuations | ❌ untranslated | ✅ translated, structure intact |
| Placeholders | ✅ | ✅ |
| Separators, comments, unicode | ✅ | ✅ |

## Known residual (model behavior, not a code path)

The word immediately after a segment boundary occasionally stays untranslated — it translated in some runs and not others across repeated identical requests. That's m2m100 non-determinism at the seam, not something the code can force. It's cosmetic: structure, placeholders and escapes are all correct either way.
