### PR TITLE
ci: file a GitHub issue when CI fails on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,52 @@ jobs:
         run: npx wrangler deploy --env staging
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+  # Failures on main are otherwise invisible: PR checks stay green because
+  # deploy-staging is push-only, so a broken deploy is only ever discovered by
+  # someone happening to look at the Actions tab. File an issue instead, and
+  # comment on the existing one rather than opening a new issue per failure.
+  notify-failure:
+    runs-on: ubuntu-latest
+    needs: [test, deploy-staging]
+    if: ${{ failure() && github.event_name == 'push' }}
+    permissions:
+      issues: write
+
+    steps:
+      - name: Open or update the CI failure issue
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const body = [
+              'CI failed on `main`.',
+              '',
+              `- Run: ${runUrl}`,
+              `- Commit: \`${context.sha.slice(0, 7)}\``,
+            ].join('\n');
+
+            const { data: open } = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              state: 'open',
+              labels: 'ci-failure',
+            });
+
+            if (open.length > 0) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: open[0].number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner,
+                repo,
+                title: 'CI failure on main',
+                body,
+                labels: ['ci-failure'],
+              });
+            }


### PR DESCRIPTION
## Problem

Failures on `main` are effectively invisible. `deploy-staging` is push-only, so PR checks stay green and a broken deploy is only discovered by someone happening to open the Actions tab. That's exactly how the Node 20 breakage sat unnoticed for **five weeks** across three merges.

## Change

A `notify-failure` job that opens an issue labelled `ci-failure` on failure — or **comments on the existing open one** instead of filing a new issue per failure.

The dedup is the important part. Without it, the three June/July failures would have opened three separate issues, and that noise is what trains you to ignore the signal.

## Why an issue rather than email or chat

- No Slack/Discord webhook secret is configured, so chat would mean new infrastructure
- GitHub's built-in failure emails may already have been firing for five weeks and didn't land — more email wasn't the answer
- An open issue **persists until someone closes it**; email gets skimmed and buried

## Verified before merging

Tested end-to-end on this branch with the trigger temporarily widened and a deliberate failing step, then reverted:

| Check | Result |
|---|---|
| First failure files an issue | ✅ opened #33 with run URL + commit SHA |
| Second failure dedups | ✅ commented on #33, still exactly 1 open issue |
| Runs when `deploy-staging` is skipped | ✅ confirms `failure()` overrides skipped-dependency propagation |
| Clean build doesn't fire | ✅ job skipped in 0s |

Uses `actions/github-script@v9` — `@v7` is two majors behind.

## Not included

A production deploy job. Worth noting it needs **no new secrets** — `CLOUDFLARE_API_TOKEN` already exists and `deploy-staging` uses it today. Deferred by choice, not by cost.

Also worth knowing: no failure notification would have caught the deeper problem that prod ran 21-month-old code, because nothing *failed* — prod simply isn't in CI. That needs a prod deploy job or a drift check, not alerting.
