### PR TITLE
ci: add manual production deploy and a drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Production deploys are manual and explicit: run this workflow from the
+  # Actions tab on main. Nothing deploys to production automatically.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -70,6 +73,41 @@ jobs:
 
       - name: Deploy to staging
         run: npx wrangler deploy --env staging
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+  # Manual production deploy. Runs only via workflow_dispatch on main, so a
+  # merge never ships to production on its own. Records the commit SHA on the
+  # deployed version so it is possible to tell what production is running.
+  deploy-production:
+    runs-on: ubuntu-latest
+    needs: test
+    if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
+    environment: production
+    permissions:
+      contents: read
+    concurrency:
+      group: deploy-production
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Deploy to production
+        run: |
+          npx wrangler deploy \
+            --tag "$GITHUB_SHA" \
+            --message "Deployed from main @ ${GITHUB_SHA:0:7} by @${GITHUB_ACTOR}"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 

--- a/.github/workflows/drift-check.yml
+++ b/.github/workflows/drift-check.yml
@@ -1,0 +1,118 @@
+# Production drift check.
+# Deploy-failure alerting cannot catch a production Worker that is simply stale,
+# because nothing fails — production ran 21-month-old code without a single red
+# build. This compares what production is running against what is on main and
+# files an issue when they diverge.
+name: Production drift check
+
+on:
+  schedule:
+    # Mondays, 14:00 UTC
+    - cron: '0 14 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-drift:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          # Full history so commits since the last deploy can be counted.
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Compare production against main
+        id: drift
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          deployed_at=$(npx wrangler deployments list --json | jq -r 'max_by(.created_on).created_on')
+          # Only source changes matter; a README edit is not production drift.
+          src_changed_at=$(git log -1 --format=%cI -- src/)
+
+          echo "Production last deployed: $deployed_at"
+          echo "src/ last changed:        $src_changed_at"
+
+          deployed_epoch=$(date -u -d "$deployed_at" +%s)
+          src_epoch=$(date -u -d "$src_changed_at" +%s)
+
+          {
+            echo "deployed_at=$deployed_at"
+            echo "src_changed_at=$src_changed_at"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "$src_epoch" -gt "$deployed_epoch" ]; then
+            behind=$(git log --oneline --since="$deployed_at" -- src/ | wc -l | tr -d ' ')
+            echo "drifted=true" >> "$GITHUB_OUTPUT"
+            echo "behind=$behind" >> "$GITHUB_OUTPUT"
+            echo "DRIFT: production is $behind src commit(s) behind main"
+          else
+            echo "drifted=false" >> "$GITHUB_OUTPUT"
+            echo "No drift: production is current with main"
+          fi
+
+      - name: Open or update the drift issue
+        if: steps.drift.outputs.drifted == 'true'
+        uses: actions/github-script@v9
+        env:
+          DEPLOYED_AT: ${{ steps.drift.outputs.deployed_at }}
+          SRC_CHANGED_AT: ${{ steps.drift.outputs.src_changed_at }}
+          BEHIND: ${{ steps.drift.outputs.behind }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const { DEPLOYED_AT, SRC_CHANGED_AT, BEHIND } = process.env;
+            const body = [
+              'Production is running older code than `main`.',
+              '',
+              `- Production last deployed: \`${DEPLOYED_AT}\``,
+              `- \`src/\` last changed: \`${SRC_CHANGED_AT}\``,
+              `- Unreleased \`src/\` commits: **${BEHIND}**`,
+              '',
+              'Deploy with the **CI** workflow via *Run workflow* on `main`.',
+              '',
+              `Detected by ${runUrl}`,
+            ].join('\n');
+
+            const { data: open } = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              state: 'open',
+              labels: 'prod-drift',
+            });
+
+            if (open.length > 0) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: open[0].number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner,
+                repo,
+                title: 'Production is behind main',
+                body,
+                labels: ['prod-drift'],
+              });
+            }


### PR DESCRIPTION
## Problem

Production had **no CI path at all** — it was only ever deployed from a laptop. That's how it ended up running 21-month-old code with no failing build to show for it. Deploy-failure alerting can't catch a Worker that's merely *stale*, because nothing fails.

## `deploy-production` (ci.yml)

Manual `workflow_dispatch` on `main` only — **merging never ships to production on its own**.

- Reuses the existing `CLOUDFLARE_API_TOKEN` secret that `deploy-staging` already uses — **no new credentials**
- Gated behind the `test` job and a `production` environment (so you can add required reviewers later if you want)
- Serialised via a concurrency group
- Records the commit SHA on the deployed version via `--tag`/`--message`, so it's finally possible to tell what production is running

## `drift-check.yml`

Weekly (plus manual) comparison of the last production deploy against the newest commit touching `src/`. Files a `prod-drift` issue when production falls behind, commenting on the existing issue rather than opening one per run.

Only `src/` counts — a README edit isn't production drift.

## Verified before merging

Tested with a temporary push trigger and the deployed-at date hardcoded to the historical `2024-10-04` value, then reverted:

| Path | Result |
|---|---|
| Drift detected | ✅ filed #34 reporting **15 unreleased src commits** — matches real history (13 since the Sept 2024 baseline + today's 2) |
| No drift | ✅ verified against live values: prod `20:46:56Z` vs `src/` `20:34:58Z`, 0 behind |
| Issue dedup | ✅ same proven pattern as `notify-failure` |

Uses `actions/github-script@v9`, and passes step outputs through `env` rather than interpolating them into the script body.

## Still to validate after merge

`deploy-production` can't be dispatched until it's on the default branch. First dispatch will confirm the token's scope covers the production Worker — expected, since it's the same account that deploys staging, but unproven until it runs.