### PR TITLE
fix: stop the model destroying placeholders during translation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,8 +34,14 @@ const SUPPORTED_LANGUAGES = [
 const SEGMENT_DELIMITER = "__SEG__";
 
 // Prefix for the markers that stand in for placeholders during translation.
-// Shares the plain-ASCII requirement described above for SEGMENT_DELIMITER.
-const PLACEHOLDER_MARKER_PREFIX = "__PH_";
+// Shares the plain-ASCII requirement described above for SEGMENT_DELIMITER, and
+// must additionally avoid underscores: the previous __PH_n__ form came back from
+// the model as PH_0, _PH_0__ or PH_0__ roughly half the time, and a mangled marker
+// no longer matches on the way back, so the placeholder it stood for was silently
+// dropped from the output file. A bare alphanumeric token survives instead --
+// XQZ<n> round-tripped intact in fr/es/de/ja/zh, next to punctuation, inside
+// parentheses, and across double-digit indexes.
+const PLACEHOLDER_MARKER_PREFIX = "XQZ";
 
 // Pattern to match placeholders in property values
 const PLACEHOLDER_REGEX = /\{[0-9a-zA-Z_,.#:\s]+\}|\$\{[0-9a-zA-Z_.:-]+\}|%[0-9]*\$?[-+#0-9.]*[a-zA-Z]/g;
@@ -163,13 +169,15 @@ async function handleTranslation(request: Request, env: Env): Promise<Response> 
 
 	const text = await file.text();
 
-	const { translatedText, failedEntries, attemptedEntries } = await translateMessages(text, languageCode, env);
+	const { translatedText, failedEntries, attemptedEntries, serviceErrors } = await translateMessages(text, languageCode, env);
 
-	// Every translatable entry failing means the model or binding is down, not that
-	// a few awkward strings tripped it up, so fail loudly rather than hand back a
-	// file that looks translated but is not. This replaces an eager probe
-	// translation that doubled the AI calls on every single request.
-	if (attemptedEntries > 0 && failedEntries === attemptedEntries) {
+	// Every attempted entry erroring at the API means the model or binding is down,
+	// not that a few awkward strings tripped it up, so fail loudly rather than hand
+	// back a file that looks translated but is not. This replaces an eager probe
+	// translation that doubled the AI calls on every single request. Only true API
+	// errors count: an entry rejected for lost markers still returns the caller's
+	// file, with the failure reported in X-Translation-Failures.
+	if (attemptedEntries > 0 && serviceErrors === attemptedEntries) {
 		return new Response("Translation service error: no entries could be translated.", { status: 500 });
 	}
 
@@ -190,6 +198,7 @@ async function handleTranslation(request: Request, env: Env): Promise<Response> 
 interface TranslationResult {
 	translatedText: string;
 	failedEntries: number;
+	serviceErrors: number;
 	attemptedEntries: number;
 }
 
@@ -201,6 +210,9 @@ async function translateMessages(text: string, targetLanguage: string, env: Env)
 	const entries = buildEntries(lines);
 	const BATCH_SIZE = 100; // Process up to 100 translations concurrently
 	let failedEntries = 0;
+	// Failures caused by the AI call itself throwing, as opposed to a translation
+	// that came back unusable. Only these can mark the whole request as a 500.
+	let serviceErrors = 0;
 	// Entries actually sent to the model. Comments, blank lines and unparseable
 	// lines are skipped rather than attempted, so counting them would make a
 	// comment-heavy file look like a total translation failure.
@@ -210,16 +222,19 @@ async function translateMessages(text: string, targetLanguage: string, env: Env)
 		const batch = entries.slice(i, i + BATCH_SIZE);
 		const translationPromises = batch.map(async (entry) => {
 			const entryLines = entry.indexes.map((idx) => lines[idx]);
-			const { translatedLines: translatedEntryLines, failed, attempted } = await translateEntry(entryLines, targetLanguage, env);
-			return { entry, translatedEntryLines, failed, attempted };
+			const { translatedLines: translatedEntryLines, failed, attempted, serviceError } = await translateEntry(entryLines, targetLanguage, env);
+			return { entry, translatedEntryLines, failed, attempted, serviceError };
 		});
 		const batchResults = await Promise.all(translationPromises);
-		for (const { entry, translatedEntryLines, failed, attempted } of batchResults) {
+		for (const { entry, translatedEntryLines, failed, attempted, serviceError } of batchResults) {
 			if (attempted) {
 				attemptedEntries++;
 			}
 			if (failed) {
 				failedEntries++;
+			}
+			if (serviceError) {
+				serviceErrors++;
 			}
 			entry.indexes.forEach((lineIndex, idx) => {
 				translatedLines[lineIndex] = translatedEntryLines[idx];
@@ -229,7 +244,7 @@ async function translateMessages(text: string, targetLanguage: string, env: Env)
 
 	const joined = translatedLines.join("\n");
 	const translatedText = newline === "\n" ? joined : joined.replace(/\n/g, newline);
-	return { translatedText, failedEntries, attemptedEntries };
+	return { translatedText, failedEntries, attemptedEntries, serviceErrors };
 }
 
 async function translateText(text: string, targetLanguage: string, env: Env): Promise<string> {
@@ -259,6 +274,11 @@ interface EntryTranslationResult {
 	// False when the entry was never sent to the model (comment, blank, unparseable,
 	// or carrying text that would collide with our internal markers).
 	attempted: boolean;
+	// True only when the AI call itself threw. An entry whose translation came back
+	// unusable (segments miscounted, markers lost) is a failed entry but not evidence
+	// that the service is down, so it must not be able to turn the whole request into
+	// a 500 -- the caller still gets their file, with the failure counted in the header.
+	serviceError: boolean;
 }
 
 async function translateEntry(lines: string[], targetLanguage: string, env: Env): Promise<EntryTranslationResult> {
@@ -266,13 +286,13 @@ async function translateEntry(lines: string[], targetLanguage: string, env: Env)
 	const trimmedFirstLine = firstLine.trim();
 
 	if (!trimmedFirstLine || trimmedFirstLine.startsWith("#") || trimmedFirstLine.startsWith("!")) {
-		return { translatedLines: lines, failed: false, attempted: false };
+		return { translatedLines: lines, failed: false, attempted: false, serviceError: false };
 	}
 
 	const segments: Segment[] = [];
 	const firstSegment = parseFirstLine(firstLine);
 	if (!firstSegment) {
-		return { translatedLines: lines, failed: false, attempted: false };
+		return { translatedLines: lines, failed: false, attempted: false, serviceError: false };
 	}
 	segments.push(firstSegment);
 
@@ -284,16 +304,16 @@ async function translateEntry(lines: string[], targetLanguage: string, env: Env)
 	const unescapedValues = segments.map(segment => unescapePropertiesText(segment.value));
 
 	if (unescapedValues.every(value => value === "")) {
-		return { translatedLines: lines, failed: false, attempted: false };
+		return { translatedLines: lines, failed: false, attempted: false, serviceError: false };
 	}
 
 	// Source text containing either internal marker would survive the round trip and
 	// then be mangled on the way back out: SEGMENT_DELIMITER would split the entry
-	// into the wrong number of segments, and a literal __PH_n__ would be rewritten by
+	// into the wrong number of segments, and a literal XQZ<n> would be rewritten by
 	// restorePlaceholders into whatever placeholder happened to take that index.
 	// Leaving such entries untranslated is the safe outcome.
 	if (unescapedValues.some(value => value.includes(SEGMENT_DELIMITER) || value.includes(PLACEHOLDER_MARKER_PREFIX))) {
-		return { translatedLines: lines, failed: false, attempted: false };
+		return { translatedLines: lines, failed: false, attempted: false, serviceError: false };
 	}
 
 	const placeholderCounter = { current: 0 };
@@ -308,7 +328,21 @@ async function translateEntry(lines: string[], targetLanguage: string, env: Env)
 		const translatedSegments = translatedCombined.split(SEGMENT_DELIMITER);
 
 		if (translatedSegments.length !== segments.length) {
-			return { translatedLines: lines, failed: true, attempted: true };
+			return { translatedLines: lines, failed: true, attempted: true, serviceError: false };
+		}
+
+		// Checked before anything is written, and per segment: a marker the model
+		// relocated across a segment boundary is just as unrestorable as one it
+		// mangled, since each segment is restored with only its own tokens.
+		const lostMarkers = segments.some(
+			(_, idx) => !markersSurvived(translatedSegments[idx], maskedSegments[idx].tokens)
+		);
+		if (lostMarkers) {
+			logError("placeholder_markers_lost", {
+				entryKey: firstLine.split(/[=:\s]/)[0]?.trim() || "unknown",
+				targetLanguage
+			});
+			return { translatedLines: lines, failed: true, attempted: true, serviceError: false };
 		}
 
 		const translatedLines = segments.map((segment, idx) => {
@@ -322,13 +356,13 @@ async function translateEntry(lines: string[], targetLanguage: string, env: Env)
 			const escapedValue = escapePropertiesText(restoredPlaceholders);
 			return `${segment.prefix}${escapedValue}${segment.suffix}`;
 		});
-		return { translatedLines, failed: false, attempted: true };
+		return { translatedLines, failed: false, attempted: true, serviceError: false };
 	} catch (error) {
 		logError("entry_translation_failed", {
 			entryKey: firstLine.split(/[=:\s]/)[0]?.trim() || "unknown",
 			error: error instanceof Error ? error.message : String(error)
 		});
-		return { translatedLines: lines, failed: true, attempted: true };
+		return { translatedLines: lines, failed: true, attempted: true, serviceError: true };
 	}
 }
 
@@ -639,7 +673,7 @@ function escapePropertiesText(value: string): string {
 function maskPlaceholders(value: string, counter: { current: number }): { text: string; tokens: PlaceholderToken[] } {
 	const tokens: PlaceholderToken[] = [];
 	const mask = (match: string) => {
-		const marker = `${PLACEHOLDER_MARKER_PREFIX}${counter.current++}__`;
+		const marker = `${PLACEHOLDER_MARKER_PREFIX}${counter.current++}`;
 		tokens.push({ marker, original: match });
 		return marker;
 	};
@@ -652,13 +686,24 @@ function maskPlaceholders(value: string, counter: { current: number }): { text: 
 }
 
 function restorePlaceholders(text: string, tokens: PlaceholderToken[]): string {
-	let restored = text;
+	// Longest marker first: the markers carry no terminator, so restoring XQZ1
+	// before XQZ10 would consume that marker's prefix and strand a loose "0".
+	const ordered = [...tokens].sort((a, b) => b.marker.length - a.marker.length);
 
-	for (const token of tokens) {
+	let restored = text;
+	for (const token of ordered) {
 		restored = restored.split(token.marker).join(token.original);
 	}
 
 	return restored;
+}
+
+// Restoration matches markers exactly, so a marker the model dropped or mangled can
+// never be matched and its placeholder would vanish from the output without trace.
+// Checking first turns that silent corruption into an ordinary entry failure, which
+// falls back to the untranslated original and is reported via X-Translation-Failures.
+function markersSurvived(text: string, tokens: PlaceholderToken[]): boolean {
+	return tokens.every(token => text.includes(token.marker));
 }
 
 // Export parsing functions for testing

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -217,8 +217,10 @@ describe('TranslateMessages Worker', () => {
 	});
 
 	it('unescapes and re-escapes property values during translation', async () => {
+		// The masked tab comes back as its marker, not as a raw tab: a model that
+		// returns the tab verbatim has destroyed the marker, which is a failed entry.
 		const mockRun = vi.fn()
-			.mockResolvedValueOnce({ translated_text: 'Salut monde!\u00E9\tLigne\\Cassé' });
+			.mockResolvedValueOnce({ translated_text: 'Salut monde!\u00E9XQZ0Ligne\\Cassé' });
 
 		const mockEnv = {
 			...env,
@@ -274,7 +276,7 @@ describe('TranslateMessages Worker', () => {
 
 	it('protects placeholder tokens during translation', async () => {
 		const mockRun = vi.fn()
-			.mockResolvedValueOnce({ translated_text: 'Salut __PH_0__! __PH_1__ __PH_2__' });
+			.mockResolvedValueOnce({ translated_text: 'Salut XQZ0! XQZ1 XQZ2' });
 
 		const mockEnv = {
 			...env,
@@ -559,11 +561,57 @@ describe('TranslateMessages Worker', () => {
 		expect(response.status).toBe(200);
 	});
 
+	it('falls back to the original when the model mangles a placeholder marker', async () => {
+		// The real m2m100 model did exactly this to the old __PH_n__ markers, returning
+		// PH_0 / _PH_0__ / PH_0__ roughly half the time. Restoration matches exactly, so
+		// the placeholder used to vanish and literal marker debris shipped in its place.
+		const mockRun = vi.fn().mockImplementation((_model, args) =>
+			Promise.resolve({ translated_text: args.text.replace(/XQZ(\d+)/g, 'PH_$1') })
+		);
+		const mockEnv = { ...env, AI: { run: mockRun } };
+
+		const fileContent = "greeting=Hello {0}\n";
+		const request = new IncomingRequest('http://example.com', {
+			method: 'POST',
+			body: buildForm(fileContent, 'fr')
+		});
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, mockEnv, ctx);
+		await waitOnExecutionContext(ctx);
+
+		expect(response.status).toBe(200);
+		// Untranslated but intact beats translated with {0} destroyed, and the user is
+		// told rather than left to discover it in production.
+		expect(await response.text()).toBe(fileContent);
+		expect(response.headers.get('X-Translation-Failures')).toBe('1');
+	});
+
+	it('restores double-digit placeholders without clobbering single-digit ones', async () => {
+		// Markers carry no terminator, so XQZ1 is a prefix of XQZ10 and restoring in
+		// token order would consume it and strand a loose "0".
+		const mockRun = vi.fn().mockImplementation((_model, args) =>
+			Promise.resolve({ translated_text: args.text })
+		);
+		const mockEnv = { ...env, AI: { run: mockRun } };
+
+		const values = Array.from({ length: 12 }, (_, i) => `{${i}}`).join(' ');
+		const request = new IncomingRequest('http://example.com', {
+			method: 'POST',
+			body: buildForm(`many=${values}\n`, 'fr')
+		});
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, mockEnv, ctx);
+		await waitOnExecutionContext(ctx);
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe(`many=${values}\n`);
+	});
+
 	it('leaves entries containing the placeholder marker untranslated', async () => {
 		const mockRun = vi.fn().mockResolvedValue({ translated_text: 'Bonjour' });
 		const mockEnv = { ...env, AI: { run: mockRun } };
 
-		const fileContent = "literal=Value with __PH_0__ inside\n";
+		const fileContent = "literal=Value with XQZ0 inside\n";
 		const request = new IncomingRequest('http://example.com', {
 			method: 'POST',
 			body: buildForm(fileContent, 'fr')

--- a/test/parsing.spec.ts
+++ b/test/parsing.spec.ts
@@ -299,28 +299,28 @@ describe('maskPlaceholders', () => {
 	it('masks simple numbered placeholders', () => {
 		const counter = { current: 0 };
 		const result = maskPlaceholders('Hello {0}!', counter);
-		expect(result.text).toBe('Hello __PH_0__!');
-		expect(result.tokens).toEqual([{ marker: '__PH_0__', original: '{0}' }]);
+		expect(result.text).toBe('Hello XQZ0!');
+		expect(result.tokens).toEqual([{ marker: 'XQZ0', original: '{0}' }]);
 	});
 
 	it('masks multiple placeholders', () => {
 		const counter = { current: 0 };
 		const result = maskPlaceholders('{0} and {1}', counter);
-		expect(result.text).toBe('__PH_0__ and __PH_1__');
+		expect(result.text).toBe('XQZ0 and XQZ1');
 		expect(result.tokens).toHaveLength(2);
 	});
 
 	it('masks Spring-style placeholders', () => {
 		const counter = { current: 0 };
 		const result = maskPlaceholders('Hello ${user.name}!', counter);
-		expect(result.text).toBe('Hello __PH_0__!');
+		expect(result.text).toBe('Hello XQZ0!');
 		expect(result.tokens[0].original).toBe('${user.name}');
 	});
 
 	it('masks printf-style placeholders', () => {
 		const counter = { current: 0 };
 		const result = maskPlaceholders('Value: %s', counter);
-		expect(result.text).toBe('Value: __PH_0__');
+		expect(result.text).toBe('Value: XQZ0');
 		expect(result.tokens[0].original).toBe('%s');
 	});
 
@@ -333,7 +333,7 @@ describe('maskPlaceholders', () => {
 	it('preserves counter across calls', () => {
 		const counter = { current: 5 };
 		const result = maskPlaceholders('{0}', counter);
-		expect(result.tokens[0].marker).toBe('__PH_5__');
+		expect(result.tokens[0].marker).toBe('XQZ5');
 		expect(counter.current).toBe(6);
 	});
 
@@ -347,22 +347,22 @@ describe('maskPlaceholders', () => {
 
 describe('restorePlaceholders', () => {
 	it('restores simple placeholder', () => {
-		const tokens: PlaceholderToken[] = [{ marker: '__PH_0__', original: '{0}' }];
-		const result = restorePlaceholders('Bonjour __PH_0__!', tokens);
+		const tokens: PlaceholderToken[] = [{ marker: 'XQZ0', original: '{0}' }];
+		const result = restorePlaceholders('Bonjour XQZ0!', tokens);
 		expect(result).toBe('Bonjour {0}!');
 	});
 
 	it('restores multiple placeholders', () => {
 		const tokens: PlaceholderToken[] = [
-			{ marker: '__PH_0__', original: '{0}' },
-			{ marker: '__PH_1__', original: '{1}' }
+			{ marker: 'XQZ0', original: '{0}' },
+			{ marker: 'XQZ1', original: '{1}' }
 		];
-		const result = restorePlaceholders('__PH_0__ et __PH_1__', tokens);
+		const result = restorePlaceholders('XQZ0 et XQZ1', tokens);
 		expect(result).toBe('{0} et {1}');
 	});
 
 	it('handles missing markers gracefully', () => {
-		const tokens: PlaceholderToken[] = [{ marker: '__PH_0__', original: '{0}' }];
+		const tokens: PlaceholderToken[] = [{ marker: 'XQZ0', original: '{0}' }];
 		const result = restorePlaceholders('No markers here', tokens);
 		expect(result).toBe('No markers here');
 	});
@@ -370,6 +370,17 @@ describe('restorePlaceholders', () => {
 	it('handles empty tokens array', () => {
 		const result = restorePlaceholders('Hello World', []);
 		expect(result).toBe('Hello World');
+	});
+
+	it('does not let a short marker consume the prefix of a longer one', () => {
+		// XQZ1 is a prefix of XQZ10, and the markers carry no terminator. Restoring in
+		// token order would rewrite XQZ10 into "{1}0".
+		const tokens: PlaceholderToken[] = [
+			{ marker: 'XQZ1', original: '{1}' },
+			{ marker: 'XQZ10', original: '{10}' }
+		];
+		const result = restorePlaceholders('XQZ10 then XQZ1', tokens);
+		expect(result).toBe('{10} then {1}');
 	});
 });
 


### PR DESCRIPTION
Found by testing #36 on staging. Placeholder protection was broken against the real model — roughly half of all placeholders were being destroyed.

## The bug

```
a=Hello {0}                    → a=Bonne journée PH_0            ✗ {0} destroyed
b=Welcome back, {0}!           → b=Bienvenue à nouveau, _PH_0__  ✗ destroyed
c=You have {0} of {1} messages → c=Vous avez {0} de messages {1} ✓ survived
d=Hi ${name}                   → d=Bonjour PH_0                  ✗ destroyed
```

m2m100 strips the underscores from the `__PH_0__` marker, sometimes partially (`PH_0`, `_PH_0__`, `PH_0__`). `restorePlaceholders` matches exactly, so a mangled marker never matches, the placeholder is never restored, and literal marker debris ships in the output file.

This is the same failure mode already documented for `SEGMENT_DELIMITER` and U+241E (`src/index.ts:30-34`) — the model mangles markers. It was fixed for the delimiter and never for placeholders. Pre-existing, not introduced by #36 (`git show c511828` confirms the marker string was byte-identical before and after).

For a tool whose entire job is Spring `messages.properties` files, which are full of `{0}`, this is a core correctness problem.

## Fix

**1. Marker format** — `__PH_n__` → `XQZ<n>`. Underscore-wrapped tokens are what the model mangles; bare alphanumeric tokens survive. Probed against the deployed staging Worker:

| Marker | Survived |
|---|---|
| `XQZ<n>` | **35/35** across fr/es/de/ja/zh |
| `[[0]]` | 0/3 — dropped entirely |
| `<<0>>` | 0/3 — became `« 0 »` |
| `#0#` | survived, but left the rest of the sentence untranslated |

The `XQZ<n>` probe covered punctuation adjacency, parentheses, sentence-initial and final position, and `XQZ9`/`XQZ10`/`XQZ11` staying distinct.

**2. Verification** — markers are checked for survival before anything is written, per segment. A marker the model dropped, mangled, or relocated across a segment boundary now fails the entry, which falls back to the untranslated original and is counted in `X-Translation-Failures`. Silent corruption becomes a reported failure. Untranslated-but-intact beats translated-with-`{0}`-destroyed.

**3. Failure classification** — marker loss is not evidence the service is down, so it must not turn a single-entry file into a 500. `translateEntry` now distinguishes a service error (the AI call threw) from an unusable translation, and only all-service-errors yields a 500. This fell out of writing the test for #2, which initially returned 500 for a one-line file.

Restoration also runs longest-marker-first now: the new markers have no terminator, so `XQZ1` is a prefix of `XQZ10` and token-order restoration would strand a loose `0`.

## Why 89 green tests missed it

The mocks returned text the real model does not produce. `protects placeholder tokens during translation` echoed the marker back perfectly; `unescapes and re-escapes property values` returned a raw tab where the marker belonged (which passed only because re-escaping coincidentally reproduced the expected output). Both now model real behavior.

New coverage: marker mangling → fallback + failure count; double-digit restoration end-to-end; and a `restorePlaceholders` unit test for the prefix-collision case.

## Verification

- `npm test` — 92 passing (89 before; 3 new, 2 mocks corrected).
- `npx tsc --noEmit` — clean.
- Staging verification against the real model to follow once merged.
