### PR TITLE
fix: recover placeholders the model loses instead of giving up on the entry

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,11 @@ export interface PlaceholderToken {
 	original: string;
 }
 
+export interface MaskedSegment {
+	text: string;
+	tokens: PlaceholderToken[];
+}
+
 // Supported language codes for m2m100 model
 const SUPPORTED_LANGUAGES = [
 	"af", "am", "ar", "ast", "az", "ba", "be", "bg", "bn", "br", "bs", "ca", "ceb", "cs", "cy", "da", 
@@ -42,6 +47,19 @@ const SEGMENT_DELIMITER = "__SEG__";
 // XQZ<n> round-tripped intact in fr/es/de/ja/zh, next to punctuation, inside
 // parentheses, and across double-digit indexes.
 const PLACEHOLDER_MARKER_PREFIX = "XQZ";
+
+// m2m100 degenerates on very short inputs: "Hi XQZ0" comes back with the marker
+// dropped entirely, while "Hi XQZ0." translates correctly and keeps it. Measured
+// against the deployed Worker, a trailing period rescued every short-input failure
+// in fr and pt, and "Hi {0}" failed identically to "Hi ${name}" -- so this is an
+// input-length pathology, not anything to do with placeholder syntax.
+const RETRY_TERMINATOR = ".";
+
+// Only period-like characters are stripped back off, because a period is what we
+// appended; an exclamation or question mark in the output was the model's own choice.
+const RETRY_TERMINATOR_REGEX = /[.。．]\s*$/;
+
+const ENDS_WITH_TERMINATOR = /[.!?。．！？…]\s*$/;
 
 // Pattern to match placeholders in property values
 const PLACEHOLDER_REGEX = /\{[0-9a-zA-Z_,.#:\s]+\}|\$\{[0-9a-zA-Z_.:-]+\}|%[0-9]*\$?[-+#0-9.]*[a-zA-Z]/g;
@@ -268,6 +286,33 @@ async function translateText(text: string, targetLanguage: string, env: Env): Pr
 	}
 }
 
+// One translation attempt: returns the per-segment text with every marker present
+// and canonical, or null if the result is unusable and the caller should give up or
+// retry. Never returns a partially usable result -- a caller that wrote one out
+// would be shipping a file with placeholders silently missing.
+async function translateSegments(
+	combinedValue: string,
+	maskedSegments: MaskedSegment[],
+	targetLanguage: string,
+	env: Env
+): Promise<string[] | null> {
+	const translatedCombined = await translateText(combinedValue, targetLanguage, env);
+	const translatedSegments = translatedCombined.split(SEGMENT_DELIMITER).map(normalizeMarkers);
+
+	if (translatedSegments.length !== maskedSegments.length) {
+		return null;
+	}
+
+	// Checked per segment: a marker the model relocated across a segment boundary is
+	// just as unrestorable as one it mangled, since each segment is restored with
+	// only its own tokens.
+	const lostMarkers = maskedSegments.some(
+		(masked, idx) => !markersSurvived(translatedSegments[idx], masked.tokens)
+	);
+
+	return lostMarkers ? null : translatedSegments;
+}
+
 interface EntryTranslationResult {
 	translatedLines: string[];
 	failed: boolean;
@@ -324,27 +369,29 @@ async function translateEntry(lines: string[], targetLanguage: string, env: Env)
 	const combinedValue = maskedSegments.map(segment => segment.text).join(`${SEGMENT_DELIMITER} `);
 
 	try {
-		const translatedCombined = await translateText(combinedValue, targetLanguage, env);
-		const translatedSegments = translatedCombined.split(SEGMENT_DELIMITER);
+		let translatedSegments = await translateSegments(combinedValue, maskedSegments, targetLanguage, env);
 
-		if (translatedSegments.length !== segments.length) {
-			return { translatedLines: lines, failed: true, attempted: true, serviceError: false };
+		// The model is deterministic -- the same input loses the same marker every
+		// time -- so a plain retry is guaranteed to waste a call. Perturbing the input
+		// is what actually changes the outcome, and only for an entry that would
+		// otherwise ship untranslated.
+		let addedRetryTerminator = false;
+		if (!translatedSegments && !ENDS_WITH_TERMINATOR.test(combinedValue)) {
+			translatedSegments = await translateSegments(
+				`${combinedValue}${RETRY_TERMINATOR}`, maskedSegments, targetLanguage, env
+			);
+			addedRetryTerminator = translatedSegments !== null;
 		}
 
-		// Checked before anything is written, and per segment: a marker the model
-		// relocated across a segment boundary is just as unrestorable as one it
-		// mangled, since each segment is restored with only its own tokens.
-		const lostMarkers = segments.some(
-			(_, idx) => !markersSurvived(translatedSegments[idx], maskedSegments[idx].tokens)
-		);
-		if (lostMarkers) {
-			logError("placeholder_markers_lost", {
+		if (!translatedSegments) {
+			logError("entry_translation_unusable", {
 				entryKey: firstLine.split(/[=:\s]/)[0]?.trim() || "unknown",
 				targetLanguage
 			});
 			return { translatedLines: lines, failed: true, attempted: true, serviceError: false };
 		}
 
+		const lastIndex = segments.length - 1;
 		const translatedLines = segments.map((segment, idx) => {
 			// Drop the padding space introduced by the join. Continuation values never
 			// begin with whitespace (parseContinuationLine moves it into the prefix),
@@ -352,7 +399,12 @@ async function translateEntry(lines: string[], targetLanguage: string, env: Env)
 			const translatedSegment = idx === 0
 				? translatedSegments[idx]
 				: translatedSegments[idx].replace(/^[ \t]+/, "");
-			const restoredPlaceholders = restorePlaceholders(translatedSegment, maskedSegments[idx].tokens);
+			// Remove only a terminator we introduced ourselves, and only from the tail
+			// segment where it was appended. Punctuation the model chose is left alone.
+			const withoutRetryTerminator = addedRetryTerminator && idx === lastIndex
+				? translatedSegment.replace(RETRY_TERMINATOR_REGEX, "")
+				: translatedSegment;
+			const restoredPlaceholders = restorePlaceholders(withoutRetryTerminator, maskedSegments[idx].tokens);
 			const escapedValue = escapePropertiesText(restoredPlaceholders);
 			return `${segment.prefix}${escapedValue}${segment.suffix}`;
 		});
@@ -670,7 +722,7 @@ function escapePropertiesText(value: string): string {
 	return result.join("");
 }
 
-function maskPlaceholders(value: string, counter: { current: number }): { text: string; tokens: PlaceholderToken[] } {
+function maskPlaceholders(value: string, counter: { current: number }): MaskedSegment {
 	const tokens: PlaceholderToken[] = [];
 	const mask = (match: string) => {
 		const marker = `${PLACEHOLDER_MARKER_PREFIX}${counter.current++}`;
@@ -696,6 +748,17 @@ function restorePlaceholders(text: string, tokens: PlaceholderToken[]): string {
 	}
 
 	return restored;
+}
+
+// The model sometimes returns a marker with whitespace inserted or its case altered
+// ("XQZ 0", "xqz0"). Canonicalising those before matching recovers the placeholder
+// without spending another call. Safe because the collision guard rejects any source
+// text containing the prefix, so every marker-shaped run in a translation started
+// life as one of ours.
+const MARKER_VARIANT_REGEX = new RegExp(`${PLACEHOLDER_MARKER_PREFIX}\\s*(\\d+)`, "gi");
+
+function normalizeMarkers(text: string): string {
+	return text.replace(MARKER_VARIANT_REGEX, (_match, index: string) => `${PLACEHOLDER_MARKER_PREFIX}${index}`);
 }
 
 // Restoration matches markers exactly, so a marker the model dropped or mangled can

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -586,6 +586,96 @@ describe('TranslateMessages Worker', () => {
 		expect(response.headers.get('X-Translation-Failures')).toBe('1');
 	});
 
+	it('recovers markers the model spaced out or changed the case of', async () => {
+		// Cheap recovery: no extra call, just canonicalise before matching.
+		const mockRun = vi.fn().mockImplementation((_model, args) =>
+			Promise.resolve({ translated_text: args.text.replace('XQZ0', 'xqz 0') })
+		);
+		const mockEnv = { ...env, AI: { run: mockRun } };
+
+		const request = new IncomingRequest('http://example.com', {
+			method: 'POST',
+			body: buildForm("greeting=Hello {0} there\n", 'fr')
+		});
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, mockEnv, ctx);
+		await waitOnExecutionContext(ctx);
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("greeting=Hello {0} there\n");
+		expect(response.headers.get('X-Translation-Failures')).toBeNull();
+		expect(mockRun).toHaveBeenCalledTimes(1);
+	});
+
+	it('retries a lost marker with a perturbed input rather than the same one', async () => {
+		// m2m100 drops the marker from a two-token input like "Hi XQZ0" but keeps it
+		// once the input ends in a period. The model is deterministic, so resending the
+		// identical text would fail identically -- the perturbation is the whole point.
+		const mockRun = vi.fn().mockImplementation((_model, args) =>
+			args.text.endsWith('.')
+				? Promise.resolve({ translated_text: 'Salut XQZ0.' })
+				: Promise.resolve({ translated_text: 'Salut' })
+		);
+		const mockEnv = { ...env, AI: { run: mockRun } };
+
+		const request = new IncomingRequest('http://example.com', {
+			method: 'POST',
+			body: buildForm("named=Hi {0}\n", 'fr')
+		});
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, mockEnv, ctx);
+		await waitOnExecutionContext(ctx);
+
+		expect(response.status).toBe(200);
+		// The placeholder is back and the period we appended is not.
+		expect(await response.text()).toBe("named=Salut {0}\n");
+		expect(response.headers.get('X-Translation-Failures')).toBeNull();
+		expect(mockRun).toHaveBeenCalledTimes(2);
+		expect(mockRun.mock.calls[0][1].text).toBe('Hi XQZ0');
+		expect(mockRun.mock.calls[1][1].text).toBe('Hi XQZ0.');
+	});
+
+	it('does not retry a value that already ends in punctuation', async () => {
+		// The perturbation has nothing to add, so a second call could only burn quota.
+		const mockRun = vi.fn().mockResolvedValue({ translated_text: 'Salut' });
+		const mockEnv = { ...env, AI: { run: mockRun } };
+
+		const fileContent = "named=Hi {0}.\n";
+		const request = new IncomingRequest('http://example.com', {
+			method: 'POST',
+			body: buildForm(fileContent, 'fr')
+		});
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, mockEnv, ctx);
+		await waitOnExecutionContext(ctx);
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe(fileContent);
+		expect(response.headers.get('X-Translation-Failures')).toBe('1');
+		expect(mockRun).toHaveBeenCalledTimes(1);
+	});
+
+	it('keeps punctuation the model chose when the retry succeeds', async () => {
+		// We appended a period; an exclamation mark is the model's own and must survive.
+		const mockRun = vi.fn().mockImplementation((_model, args) =>
+			args.text.endsWith('.')
+				? Promise.resolve({ translated_text: 'Salut XQZ0!' })
+				: Promise.resolve({ translated_text: 'Salut' })
+		);
+		const mockEnv = { ...env, AI: { run: mockRun } };
+
+		const request = new IncomingRequest('http://example.com', {
+			method: 'POST',
+			body: buildForm("named=Hi {0}\n", 'fr')
+		});
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, mockEnv, ctx);
+		await waitOnExecutionContext(ctx);
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("named=Salut {0}\\!\n");
+	});
+
 	it('restores double-digit placeholders without clobbering single-digit ones', async () => {
 		// Markers carry no terminator, so XQZ1 is a prefix of XQZ10 and restoring in
 		// token order would consume it and strand a loose "0".


### PR DESCRIPTION
Follow-up to #37. Entries whose markers were lost fall back untranslated — safe, but it leaves real translations on the table. Two recovery layers, cheapest first.

## 1. Tolerant matching — zero extra calls

The model sometimes returns a marker with whitespace inserted or its case altered (`XQZ 0`, `xqz0`). Canonicalising before matching recovers the placeholder for free. Safe because the collision guard rejects source text containing the prefix, so every marker-shaped run in a translation started life as one of ours.

## 2. Perturbation retry — one extra call, failure path only

Measured against the deployed Worker, the residual failures turn out not to be a placeholder problem at all:

| Input | fr | pt |
|---|---|---|
| `Hi ${name}` | ✗ lost | ✗ lost |
| `Hi {0}` | ✗ lost | ✗ lost |
| `Hi ${name}.` | ✓ | ✓ |
| `Hello ${name}` | ✓ | ✓ |
| `Welcome ${name}` | ✓ | ✓ |
| `Hi ${name} and welcome` | ✓ | ✓ |

`Hi {0}` fails identically to `Hi ${name}`, so placeholder syntax isn't the variable — input length is. m2m100 produces a degenerate output on a two-token input and drops the rare token; almost any added context rescues it.

**A plain retry would be worthless.** The model is deterministic — three identical requests lost the same marker every time. Perturbing the input is what changes the outcome.

So a failed entry is retried once with a trailing period appended, unless the value already ends in terminal punctuation (nothing to add, so a second call could only burn quota). The terminator we added is then stripped back off the tail segment. Only period-like characters are stripped — an exclamation mark in the output was the model's own choice and survives.

Anything still unusable after the retry keeps the existing behavior: untranslated original, counted in `X-Translation-Failures`.

## Verification

96 tests passing (92 before), typecheck clean. New coverage: whitespace/case recovery, the retry path including the exact text of both calls, punctuation preservation, and that an already-punctuated value is never retried.

Staging verification against the real model to follow once merged.
