### PR TITLE
feat: add opt-in llama backend and a model comparison harness

### DIFF
--- a/scripts/compare-models.mjs
+++ b/scripts/compare-models.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+// Runs one .properties fixture through both translation backends and reports how
+// they differ. Written because the choice between m2m100 and an instruction-following
+// model is a quality question, and quality questions are not settled by reading
+// pricing tables.
+//
+//   node scripts/compare-models.mjs                        # staging, default languages
+//   node scripts/compare-models.mjs --languages fr,ja      # pick languages
+//   node scripts/compare-models.mjs --url http://localhost:8787 --out report.md
+//
+// What it measures objectively:
+//   - placeholder fidelity: every placeholder in the source present in the output
+//   - untranslated rate: values that came back byte-identical to the English
+//   - structural integrity: same keys, same entry count, escapes preserved
+//   - reported failures (X-Translation-Failures) and wall-clock latency
+//
+// What it deliberately does not measure: whether the translation is any *good*.
+// No automatic metric substitutes for reading the side-by-side output, which is why
+// the report includes it in full.
+
+import { readFile, writeFile } from "node:fs/promises";
+import { basename } from "node:path";
+
+const DEFAULT_URL = "https://translatemessages-staging.justblackmagic.workers.dev/";
+const DEFAULT_FIXTURE = new URL("./fixtures/comparison.properties", import.meta.url).pathname;
+const DEFAULT_LANGUAGES = ["fr", "es", "de", "ja"];
+const MODELS = ["m2m100", "llama"];
+
+// Kept in step with PLACEHOLDER_REGEX in src/index.ts. If they drift, this script
+// will happily report a fidelity score that the Worker does not actually enforce.
+const PLACEHOLDER_REGEX = /\{[0-9a-zA-Z_,.#:\s]+\}|\$\{[0-9a-zA-Z_.:-]+\}|%[0-9]*\$?[-+#0-9.]*[a-zA-Z]/g;
+
+function parseArgs(argv) {
+	const args = { url: DEFAULT_URL, file: DEFAULT_FIXTURE, languages: DEFAULT_LANGUAGES, out: null };
+	for (let i = 0; i < argv.length; i += 2) {
+		const key = argv[i]?.replace(/^--/, "");
+		const value = argv[i + 1];
+		if (!key || value === undefined) continue;
+		if (key === "languages") args.languages = value.split(",").map(entry => entry.trim()).filter(Boolean);
+		else if (key in args) args[key] = value;
+	}
+	return args;
+}
+
+// Minimal .properties reader: enough to line entries up between two runs. Mirrors the
+// Worker's notion of an entry (continuations belong to the line that opened them) so
+// the comparison counts the same things the Worker does.
+function parseEntries(text) {
+	const lines = text.replace(/\r\n?/g, "\n").split("\n");
+	const entries = [];
+
+	for (let i = 0; i < lines.length; i++) {
+		const trimmed = lines[i].trim();
+		if (!trimmed || trimmed.startsWith("#") || trimmed.startsWith("!")) continue;
+
+		let raw = lines[i];
+		while (hasContinuation(lines[i]) && i + 1 < lines.length) {
+			i++;
+			raw += `\n${lines[i]}`;
+		}
+
+		const joined = raw.replace(/\\\n\s*/g, "");
+		const separator = joined.search(/[=:]/);
+		if (separator === -1) continue;
+		entries.push({
+			key: joined.slice(0, separator).trim(),
+			value: joined.slice(separator + 1).trim()
+		});
+	}
+
+	return entries;
+}
+
+function hasContinuation(line) {
+	const trailing = line.match(/\\*$/)?.[0].length ?? 0;
+	return trailing % 2 === 1;
+}
+
+function placeholdersIn(value) {
+	return value.match(PLACEHOLDER_REGEX) ?? [];
+}
+
+async function translate({ url, content, language, model }) {
+	const form = new FormData();
+	form.append("file", new Blob([content], { type: "text/plain" }), "messages.properties");
+	form.append("language", language);
+	form.append("model", model);
+
+	const startedAt = Date.now();
+	const response = await fetch(url, { method: "POST", body: form });
+	const elapsedMs = Date.now() - startedAt;
+	const body = await response.text();
+
+	if (!response.ok) {
+		return { ok: false, status: response.status, body, elapsedMs };
+	}
+
+	return {
+		ok: true,
+		status: response.status,
+		body,
+		elapsedMs,
+		reportedFailures: Number(response.headers.get("X-Translation-Failures") ?? 0)
+	};
+}
+
+function score(sourceEntries, result) {
+	if (!result.ok) {
+		return { failed: true, status: result.status, body: result.body.slice(0, 200), elapsedMs: result.elapsedMs };
+	}
+
+	const translated = new Map(parseEntries(result.body).map(entry => [entry.key, entry.value]));
+	const rows = [];
+	let placeholderViolations = 0;
+	let unchanged = 0;
+	let missingKeys = 0;
+
+	for (const source of sourceEntries) {
+		const output = translated.get(source.key);
+		if (output === undefined) {
+			missingKeys++;
+			rows.push({ ...source, output: null, lostPlaceholders: [], unchanged: false });
+			continue;
+		}
+
+		// Counted, not just present: a value using {0} twice must come back with both.
+		const lostPlaceholders = [];
+		for (const placeholder of new Set(placeholdersIn(source.value))) {
+			const needed = placeholdersIn(source.value).filter(entry => entry === placeholder).length;
+			const found = output.split(placeholder).length - 1;
+			if (found < needed) lostPlaceholders.push(placeholder);
+		}
+		if (lostPlaceholders.length > 0) placeholderViolations++;
+
+		const isUnchanged = output === source.value;
+		if (isUnchanged) unchanged++;
+
+		rows.push({ ...source, output, lostPlaceholders, unchanged: isUnchanged });
+	}
+
+	return {
+		failed: false,
+		rows,
+		total: sourceEntries.length,
+		placeholderViolations,
+		unchanged,
+		missingKeys,
+		reportedFailures: result.reportedFailures,
+		elapsedMs: result.elapsedMs
+	};
+}
+
+function renderReport({ fixture, url, languages, results }) {
+	const lines = [];
+	lines.push(`# Model comparison: m2m100 vs llama`, "");
+	lines.push(`Fixture: \`${basename(fixture)}\` · Endpoint: \`${url}\``, "");
+
+	lines.push(`## Summary`, "");
+	lines.push(`Lower is better for every column except "translated".`, "");
+	lines.push(`| Language | Model | Translated | Unchanged | Placeholders lost | Reported failures | Missing keys | Latency |`);
+	lines.push(`|---|---|---|---|---|---|---|---|`);
+
+	for (const language of languages) {
+		for (const model of MODELS) {
+			const result = results[language][model];
+			if (result.failed) {
+				lines.push(`| ${language} | ${model} | — | — | — | — | — | HTTP ${result.status} |`);
+				continue;
+			}
+			const translated = result.total - result.unchanged - result.missingKeys;
+			lines.push(
+				`| ${language} | ${model} | ${translated}/${result.total} | ${result.unchanged} | ` +
+				`${result.placeholderViolations} | ${result.reportedFailures} | ${result.missingKeys} | ${result.elapsedMs}ms |`
+			);
+		}
+	}
+
+	lines.push("", `## Side by side`, "");
+	lines.push(`Read this part. The table above cannot tell you whether a translation is good,`);
+	lines.push(`only whether it is structurally intact.`, "");
+
+	for (const language of languages) {
+		const m2m = results[language].m2m100;
+		const llama = results[language].llama;
+		lines.push(`### ${language}`, "");
+		if (m2m.failed || llama.failed) {
+			lines.push(`One or both backends failed for this language; see the summary.`, "");
+			continue;
+		}
+
+		for (let i = 0; i < m2m.rows.length; i++) {
+			const source = m2m.rows[i];
+			const llamaRow = llama.rows[i];
+			lines.push(`**\`${source.key}\`**`, "");
+			lines.push("```");
+			lines.push(`en     ${source.value}`);
+			lines.push(`m2m    ${formatCell(source)}`);
+			lines.push(`llama  ${formatCell(llamaRow)}`);
+			lines.push("```", "");
+		}
+	}
+
+	return lines.join("\n");
+}
+
+function formatCell(row) {
+	if (row.output === null) return "<key missing from output>";
+	const notes = [];
+	if (row.lostPlaceholders.length > 0) notes.push(`LOST ${row.lostPlaceholders.join(" ")}`);
+	if (row.unchanged) notes.push("UNCHANGED");
+	return notes.length > 0 ? `${row.output}   <-- ${notes.join(", ")}` : row.output;
+}
+
+async function main() {
+	const args = parseArgs(process.argv.slice(2));
+	const content = await readFile(args.file, "utf8");
+	const sourceEntries = parseEntries(content);
+
+	console.error(`Comparing ${MODELS.join(" vs ")} on ${sourceEntries.length} entries across ${args.languages.join(", ")}`);
+	console.error(`Endpoint: ${args.url}`);
+
+	const results = {};
+	for (const language of args.languages) {
+		results[language] = {};
+		// Sequential on purpose: concurrent runs would make the latency column noise.
+		for (const model of MODELS) {
+			process.stderr.write(`  ${language}/${model} ... `);
+			const result = await translate({ url: args.url, content, language, model });
+			results[language][model] = score(sourceEntries, result);
+			console.error(result.ok ? `${result.elapsedMs}ms` : `HTTP ${result.status}`);
+		}
+	}
+
+	const report = renderReport({ fixture: args.file, url: args.url, languages: args.languages, results });
+	if (args.out) {
+		await writeFile(args.out, report, "utf8");
+		console.error(`\nWrote ${args.out}`);
+	} else {
+		console.log(report);
+	}
+}
+
+main().catch(error => {
+	console.error(error);
+	process.exit(1);
+});

--- a/scripts/fixtures/comparison.properties
+++ b/scripts/fixtures/comparison.properties
@@ -1,0 +1,49 @@
+# Fixture for scripts/compare-models.mjs.
+# Deliberately weighted towards the cases that have actually broken in production:
+# placeholders of every supported syntax, very short values, escapes, continuations
+# and inline comments. Keep entries one concept each so a diff is readable.
+
+# --- plain prose, the easy baseline ---
+app.name=Task Manager
+app.welcome=Welcome to your dashboard
+app.description=Manage your projects and collaborate with your team in one place
+
+# --- short values: m2m100 degenerates on two-token inputs ---
+button.ok=OK
+button.save=Save
+label.hi=Hi {0}
+label.bye=Bye {0}
+
+# --- numbered placeholders ---
+message.greeting=Hello {0}
+message.count=You have {0} of {1} messages
+message.repeat=Hello {0}, we said hello {0} already
+message.order={0} items shipped to {1} on {2}
+
+# --- named and printf placeholders ---
+user.welcome=Welcome back, ${name}
+user.profile=Profile for ${user.name} in ${user.role}
+stats.total=Total: %s items
+stats.indexed=%1$s scored %2$d points
+
+# --- placeholders adjacent to punctuation ---
+alert.warning=Warning, {0}!
+alert.question=Are you sure you want to delete {0}?
+alert.parens=Order ({0}) has shipped
+
+# --- escapes that must survive the round trip ---
+help.multiline=First line\nSecond line
+help.tabbed=Column one\tColumn two
+help.unicode=Café près de l’hôtel
+
+# --- continuation across lines ---
+terms.long=By continuing you agree to the terms {0} \
+    and the privacy policy {1} \
+    effective today
+
+# --- inline comment must be preserved verbatim ---
+footer.copyright=All rights reserved  # do not translate the year
+
+# --- longer prose, where translation quality is most visible ---
+error.permission=You do not have permission to perform this action. Contact your administrator if you believe this is a mistake.
+onboarding.step=Choose a workspace name. You can change it later in settings.

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,11 @@ export interface PlaceholderToken {
 export interface MaskedSegment {
 	text: string;
 	tokens: PlaceholderToken[];
+	// Placeholders deliberately left in the text for an instruction-following model to
+	// copy verbatim, rather than masked behind a marker. Verified after translation
+	// exactly as markers are, so both backends fail the same way when a placeholder
+	// does not survive.
+	literalPlaceholders: string[];
 }
 
 // Supported language codes for m2m100 model
@@ -47,6 +52,18 @@ const SEGMENT_DELIMITER = "__SEG__";
 // XQZ<n> round-tripped intact in fr/es/de/ja/zh, next to punctuation, inside
 // parentheses, and across double-digit indexes.
 const PLACEHOLDER_MARKER_PREFIX = "XQZ";
+
+// Translation backends. m2m100 is the default and the only one the frontend uses;
+// llama is opt-in via the `model` form field so its output quality can be compared
+// against m2m100 on the same input. It needs no placeholder masking, which is the
+// hypothesis being tested -- see PLACEHOLDER_MARKER_PREFIX for why masking is
+// fragile against a model that rewrites rare tokens.
+const M2M_MODEL = "@cf/meta/m2m100-1.2b";
+const LLAMA_MODEL = "@cf/meta/llama-3-8b-instruct-awq";
+
+export type ModelChoice = "m2m100" | "llama";
+export const MODEL_CHOICES: ModelChoice[] = ["m2m100", "llama"];
+const DEFAULT_MODEL: ModelChoice = "m2m100";
 
 // m2m100 degenerates on very short inputs: "Hi XQZ0" comes back with the marker
 // dropped entirely, while "Hi XQZ0." translates correctly and keeps it. Measured
@@ -185,9 +202,17 @@ async function handleTranslation(request: Request, env: Env): Promise<Response> 
 		return new Response(`Unsupported language code: ${language}. Supported languages: ${SUPPORTED_LANGUAGES.join(", ")}`, { status: 400 });
 	}
 
+	// EXPERIMENTAL, and absent from the frontend on purpose: this exists so the two
+	// backends can be compared on identical input. Omitting it keeps today's behaviour.
+	const modelEntry = formData.get("model");
+	if (modelEntry !== null && (typeof modelEntry !== "string" || !MODEL_CHOICES.includes(modelEntry as ModelChoice))) {
+		return new Response(`Unsupported model. Choose one of: ${MODEL_CHOICES.join(", ")}.`, { status: 400 });
+	}
+	const model = (modelEntry as ModelChoice | null) ?? DEFAULT_MODEL;
+
 	const text = await file.text();
 
-	const { translatedText, failedEntries, attemptedEntries, serviceErrors } = await translateMessages(text, languageCode, env);
+	const { translatedText, failedEntries, attemptedEntries, serviceErrors } = await translateMessages(text, languageCode, env, model);
 
 	// Every attempted entry erroring at the API means the model or binding is down,
 	// not that a few awkward strings tripped it up, so fail loudly rather than hand
@@ -220,7 +245,7 @@ interface TranslationResult {
 	attemptedEntries: number;
 }
 
-async function translateMessages(text: string, targetLanguage: string, env: Env): Promise<TranslationResult> {
+async function translateMessages(text: string, targetLanguage: string, env: Env, model: ModelChoice): Promise<TranslationResult> {
 	const newline = text.includes("\r\n") ? "\r\n" : "\n";
 	const normalizedText = text.replace(/\r\n?/g, "\n");
 	const lines = normalizedText.split("\n");
@@ -240,7 +265,7 @@ async function translateMessages(text: string, targetLanguage: string, env: Env)
 		const batch = entries.slice(i, i + BATCH_SIZE);
 		const translationPromises = batch.map(async (entry) => {
 			const entryLines = entry.indexes.map((idx) => lines[idx]);
-			const { translatedLines: translatedEntryLines, failed, attempted, serviceError } = await translateEntry(entryLines, targetLanguage, env);
+			const { translatedLines: translatedEntryLines, failed, attempted, serviceError } = await translateEntry(entryLines, targetLanguage, env, model);
 			return { entry, translatedEntryLines, failed, attempted, serviceError };
 		});
 		const batchResults = await Promise.all(translationPromises);
@@ -265,10 +290,14 @@ async function translateMessages(text: string, targetLanguage: string, env: Env)
 	return { translatedText, failedEntries, attemptedEntries, serviceErrors };
 }
 
-async function translateText(text: string, targetLanguage: string, env: Env): Promise<string> {
+async function translateText(text: string, targetLanguage: string, env: Env, model: ModelChoice): Promise<string> {
 	try {
+		if (model === "llama") {
+			return await translateWithInstructModel(text, targetLanguage, env);
+		}
+
 		const response = await env.AI.run(
-			"@cf/meta/m2m100-1.2b",
+			M2M_MODEL,
 			{
 				text: text,
 				source_lang: "en",
@@ -280,9 +309,70 @@ async function translateText(text: string, targetLanguage: string, env: Env): Pr
 	} catch (error) {
 		logError("translation_api_error", {
 			targetLanguage,
+			model,
 			error: error instanceof Error ? error.message : String(error)
 		});
 		throw new Error(`Translation service failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
+	}
+}
+
+// EXPERIMENTAL. Reached only via the `model=llama` form field; the default path is
+// unchanged. An instruction-following model needs no placeholder masking -- it is
+// told to copy placeholders verbatim and the result is verified the same way the
+// masked path is -- which is the whole point of the comparison.
+async function translateWithInstructModel(text: string, targetLanguage: string, env: Env): Promise<string> {
+	const response = await env.AI.run(
+		LLAMA_MODEL,
+		{
+			messages: [
+				{ role: "system", content: instructSystemPrompt(targetLanguage) },
+				{ role: "user", content: text }
+			],
+			// Deterministic output, so a rerun of the comparison is reproducible.
+			temperature: 0,
+			max_tokens: 1024
+		} as never
+	) as { response?: string };
+
+	return cleanInstructOutput(response.response ?? "");
+}
+
+function instructSystemPrompt(targetLanguage: string): string {
+	const languageName = describeLanguage(targetLanguage);
+	return [
+		`You translate strings from a Java .properties file from English into ${languageName}.`,
+		"",
+		"Rules:",
+		"- Reply with the translation only. No quotes, no preamble, no explanation, no notes.",
+		"- Copy every placeholder exactly as written, including {0}, {1}, ${name}, %s and %d.",
+		`- Copy any ${SEGMENT_DELIMITER} token exactly; it separates parts of one string.`,
+		`- Copy any ${PLACEHOLDER_MARKER_PREFIX} token followed by digits exactly.`,
+		"- Translate the wording only. Do not add, drop or reorder content.",
+		"- If the input is a single word or fragment, translate it as-is."
+	].join("\n");
+}
+
+// Small instruct models leak conversational scaffolding even when told not to.
+// Stripping it here keeps the comparison about translation quality rather than
+// about prompt obedience.
+function cleanInstructOutput(raw: string): string {
+	let text = raw.trim();
+	text = text.replace(/^(?:translation|traduction|output)\s*:\s*/i, "");
+	// Unwrap a fully quoted response, but leave quotes that are part of the string.
+	const quoted = text.match(/^"([\s\S]*)"$/) ?? text.match(/^'([\s\S]*)'$/);
+	if (quoted && !quoted[1].includes('"')) {
+		text = quoted[1];
+	}
+	return text.trim();
+}
+
+function describeLanguage(code: string): string {
+	try {
+		const name = new Intl.DisplayNames(["en"], { type: "language" }).of(code);
+		// Intl echoes the input back when it has no name for the code.
+		return name && name !== code ? name : `the language with ISO code "${code}"`;
+	} catch {
+		return `the language with ISO code "${code}"`;
 	}
 }
 
@@ -293,10 +383,11 @@ async function translateText(text: string, targetLanguage: string, env: Env): Pr
 async function translateSegments(
 	combinedValue: string,
 	maskedSegments: MaskedSegment[],
+	model: ModelChoice,
 	targetLanguage: string,
 	env: Env
 ): Promise<string[] | null> {
-	const translatedCombined = await translateText(combinedValue, targetLanguage, env);
+	const translatedCombined = await translateText(combinedValue, targetLanguage, env, model);
 	const translatedSegments = translatedCombined.split(SEGMENT_DELIMITER).map(normalizeMarkers);
 
 	if (translatedSegments.length !== maskedSegments.length) {
@@ -307,7 +398,7 @@ async function translateSegments(
 	// just as unrestorable as one it mangled, since each segment is restored with
 	// only its own tokens.
 	const lostMarkers = maskedSegments.some(
-		(masked, idx) => !markersSurvived(translatedSegments[idx], masked.tokens)
+		(masked, idx) => !markersSurvived(translatedSegments[idx], masked)
 	);
 
 	return lostMarkers ? null : translatedSegments;
@@ -326,7 +417,7 @@ interface EntryTranslationResult {
 	serviceError: boolean;
 }
 
-async function translateEntry(lines: string[], targetLanguage: string, env: Env): Promise<EntryTranslationResult> {
+async function translateEntry(lines: string[], targetLanguage: string, env: Env, model: ModelChoice): Promise<EntryTranslationResult> {
 	const firstLine = lines[0];
 	const trimmedFirstLine = firstLine.trim();
 
@@ -362,14 +453,14 @@ async function translateEntry(lines: string[], targetLanguage: string, env: Env)
 	}
 
 	const placeholderCounter = { current: 0 };
-	const maskedSegments = unescapedValues.map(value => maskPlaceholders(value, placeholderCounter));
+	const maskedSegments = unescapedValues.map(value => maskPlaceholders(value, placeholderCounter, model !== "llama"));
 	// A trailing space keeps the delimiter from fusing to the following word, which
 	// left that word untranslated. Continuation values already end with a space
 	// before their backslash, so the left-hand side needs no padding.
 	const combinedValue = maskedSegments.map(segment => segment.text).join(`${SEGMENT_DELIMITER} `);
 
 	try {
-		let translatedSegments = await translateSegments(combinedValue, maskedSegments, targetLanguage, env);
+		let translatedSegments = await translateSegments(combinedValue, maskedSegments, model, targetLanguage, env);
 
 		// The model is deterministic -- the same input loses the same marker every
 		// time -- so a plain retry is guaranteed to waste a call. Perturbing the input
@@ -378,7 +469,7 @@ async function translateEntry(lines: string[], targetLanguage: string, env: Env)
 		let addedRetryTerminator = false;
 		if (!translatedSegments && !ENDS_WITH_TERMINATOR.test(combinedValue)) {
 			translatedSegments = await translateSegments(
-				`${combinedValue}${RETRY_TERMINATOR}`, maskedSegments, targetLanguage, env
+				`${combinedValue}${RETRY_TERMINATOR}`, maskedSegments, model, targetLanguage, env
 			);
 			addedRetryTerminator = translatedSegments !== null;
 		}
@@ -722,7 +813,14 @@ function escapePropertiesText(value: string): string {
 	return result.join("");
 }
 
-function maskPlaceholders(value: string, counter: { current: number }): MaskedSegment {
+function maskPlaceholders(
+	value: string,
+	counter: { current: number },
+	// False for an instruction-following model, which is asked to copy placeholders
+	// rather than have them hidden behind markers. Control characters are masked
+	// either way: no model reliably round-trips a raw tab or newline.
+	maskPlaceholderTokens = true
+): MaskedSegment {
 	const tokens: PlaceholderToken[] = [];
 	const mask = (match: string) => {
 		const marker = `${PLACEHOLDER_MARKER_PREFIX}${counter.current++}`;
@@ -730,11 +828,11 @@ function maskPlaceholders(value: string, counter: { current: number }): MaskedSe
 		return marker;
 	};
 
-	const text = value
-		.replace(PLACEHOLDER_REGEX, mask)
+	const literalPlaceholders = maskPlaceholderTokens ? [] : (value.match(PLACEHOLDER_REGEX) ?? []);
+	const text = (maskPlaceholderTokens ? value.replace(PLACEHOLDER_REGEX, mask) : value)
 		.replace(CONTROL_CHAR_REGEX, mask);
 
-	return { text, tokens };
+	return { text, tokens, literalPlaceholders };
 }
 
 function restorePlaceholders(text: string, tokens: PlaceholderToken[]): string {
@@ -765,8 +863,19 @@ function normalizeMarkers(text: string): string {
 // never be matched and its placeholder would vanish from the output without trace.
 // Checking first turns that silent corruption into an ordinary entry failure, which
 // falls back to the untranslated original and is reported via X-Translation-Failures.
-function markersSurvived(text: string, tokens: PlaceholderToken[]): boolean {
-	return tokens.every(token => text.includes(token.marker));
+function markersSurvived(text: string, masked: MaskedSegment): boolean {
+	// Counted rather than merely present: a value with two identical placeholders
+	// must come back with both, not with one silently dropped.
+	const literalsSurvived = masked.literalPlaceholders.every(placeholder => {
+		const needed = masked.literalPlaceholders.filter(entry => entry === placeholder).length;
+		return occurrences(text, placeholder) >= needed;
+	});
+
+	return literalsSurvived && masked.tokens.every(token => text.includes(token.marker));
+}
+
+function occurrences(haystack: string, needle: string): number {
+	return needle ? haystack.split(needle).length - 1 : 0;
 }
 
 // Export parsing functions for testing

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -7,10 +7,13 @@ import worker, { type Env } from '../src/index';
 // `Request` to pass to `worker.fetch()`.
 const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
 
-function buildForm(content: string, language: string): FormData {
+function buildForm(content: string, language: string, model?: string): FormData {
 	const formData = new FormData();
 	formData.append('file', new File([content], 'messages.properties', { type: 'text/plain' }));
 	formData.append('language', language);
+	if (model !== undefined) {
+		formData.append('model', model);
+	}
 	return formData;
 }
 
@@ -816,5 +819,93 @@ describe('CORS', () => {
 		expect(response.status).toBe(200);
 		expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull();
 		expect(await response.text()).toBe("greeting=Bonjour\n");
+	});
+});
+
+// The llama backend is an experiment behind the `model` form field: it asks an
+// instruction-following model to copy placeholders rather than masking them, so it
+// can be compared against m2m100 on identical input. See scripts/compare-models.mjs.
+describe('llama backend (experimental)', () => {
+	function runWith(mockRun: ReturnType<typeof vi.fn>, content: string, model?: string) {
+		const mockEnv = { ...env, AI: { run: mockRun } };
+		const request = new IncomingRequest('http://example.com', {
+			method: 'POST',
+			body: buildForm(content, 'fr', model)
+		});
+		const ctx = createExecutionContext();
+		return worker.fetch(request, mockEnv, ctx).then(async (response) => {
+			await waitOnExecutionContext(ctx);
+			return response;
+		});
+	}
+
+	it('sends placeholders unmasked and keeps them in the output', async () => {
+		const mockRun = vi.fn().mockResolvedValue({ response: 'Bonjour {0}' });
+
+		const response = await runWith(mockRun, "greeting=Hello {0}\n", 'llama');
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("greeting=Bonjour {0}\n");
+
+		const [modelId, args] = mockRun.mock.calls[0];
+		expect(modelId).toBe('@cf/meta/llama-3-8b-instruct-awq');
+		// The whole hypothesis: the model sees the real placeholder, not a marker.
+		expect(args.messages[1].content).toBe('Hello {0}');
+		expect(args.messages[0].content).toContain('{0}');
+	});
+
+	it('defaults to m2m100 when no model is requested', async () => {
+		const mockRun = vi.fn().mockResolvedValue({ translated_text: 'Bonjour XQZ0' });
+
+		const response = await runWith(mockRun, "greeting=Hello {0}\n");
+
+		expect(response.status).toBe(200);
+		expect(mockRun.mock.calls[0][0]).toBe('@cf/meta/m2m100-1.2b');
+		// Masked, as the default path has always done.
+		expect(mockRun.mock.calls[0][1].text).toBe('Hello XQZ0');
+	});
+
+	it('rejects an unknown model', async () => {
+		const response = await runWith(vi.fn(), "greeting=Hello\n", 'gpt-9');
+
+		expect(response.status).toBe(400);
+		expect(await response.text()).toContain('Unsupported model');
+	});
+
+	it('fails the entry when the model drops a placeholder', async () => {
+		const mockRun = vi.fn().mockResolvedValue({ response: 'Bonjour' });
+
+		const response = await runWith(mockRun, "greeting=Hello {0}\n", 'llama');
+
+		// Same contract as the masked path: never ship a value with a placeholder
+		// silently missing.
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("greeting=Hello {0}\n");
+		expect(response.headers.get('X-Translation-Failures')).toBe('1');
+	});
+
+	it('fails the entry when a repeated placeholder comes back only once', async () => {
+		const mockRun = vi.fn().mockResolvedValue({ response: 'Bonjour {0}' });
+
+		const response = await runWith(mockRun, "greeting=Hello {0} and {0}\n", 'llama');
+
+		expect(await response.text()).toBe("greeting=Hello {0} and {0}\n");
+		expect(response.headers.get('X-Translation-Failures')).toBe('1');
+	});
+
+	it('strips conversational scaffolding from the reply', async () => {
+		const mockRun = vi.fn().mockResolvedValue({ response: '  Translation: "Bonjour {0}"  ' });
+
+		const response = await runWith(mockRun, "greeting=Hello {0}\n", 'llama');
+
+		expect(await response.text()).toBe("greeting=Bonjour {0}\n");
+	});
+
+	it('leaves quotes that belong to the string alone', async () => {
+		const mockRun = vi.fn().mockResolvedValue({ response: 'Il a dit "bonjour" {0}' });
+
+		const response = await runWith(mockRun, "greeting=He said \"hello\" {0}\n", 'llama');
+
+		expect(await response.text()).toBe("greeting=Il a dit \"bonjour\" {0}\n");
 	});
 });


### PR DESCRIPTION
Groundwork for deciding whether to move off m2m100, following the cost analysis. **Default behavior is unchanged** — the backend is chosen by a `model` form field the frontend never sends, and omitting it keeps m2m100.

## The hypothesis

An instruction-following model needs no placeholder masking. So the llama path sends placeholders verbatim and asks the model to copy them; the m2m100 path keeps masking them behind `XQZ<n>` markers. Control characters are still masked for both — no model round-trips a raw tab.

Both paths are verified identically: every placeholder in the source must appear in the output, **counted** rather than merely found, so a value using `{0}` twice must come back with both. Failing verification falls back untranslated and counts toward `X-Translation-Failures`, exactly as today. Neither backend can ship a value with a placeholder silently missing.

## The harness

`scripts/compare-models.mjs` runs one fixture through both backends across several languages:

```
node scripts/compare-models.mjs                    # staging, fr/es/de/ja
node scripts/compare-models.mjs --languages fr,ja --out report.md
```

It reports placeholder fidelity, untranslated rate, structural integrity, reported failures and latency — then the full side-by-side output. The objective columns can't tell you whether a translation is *good*, only whether it's structurally intact, so the side-by-side is included and the report says as much.

The fixture (`scripts/fixtures/comparison.properties`, 25 entries) is weighted towards what has actually broken: every placeholder syntax, two-token values, escapes, continuations, inline comments.

## Design note

Prototyped **unbatched, one entry per call**, deliberately. That matches m2m100's request shape so the model is the only variable in the comparison. Batching many entries per call is where the cost advantage lives and can be layered on if quality holds up — entangling it now would confound the result.

## Verification

103 tests passing (96 before). New coverage: placeholders sent unmasked to llama, m2m100 still the default and still masked, unknown model rejected, entry fails when the model drops a placeholder, entry fails when a repeated placeholder returns only once, scaffolding stripped, and quotes that belong to the string preserved.

A harness run against current staging returned byte-identical output for both columns — as expected, since deployed staging predates the `model` field and ran m2m100 twice. Real comparison numbers to follow once this is on staging.
