### PR TITLE
fix: satisfy the test typecheck for the shared llama mock helper

### DIFF
--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -827,7 +827,9 @@ describe('CORS', () => {
 // can be compared against m2m100 on identical input. See scripts/compare-models.mjs.
 describe('llama backend (experimental)', () => {
 	function runWith(mockRun: ReturnType<typeof vi.fn>, content: string, model?: string) {
-		const mockEnv = { ...env, AI: { run: mockRun } };
+		// ReturnType<typeof vi.fn> is wider than the Ai.run signature, so the shared
+		// helper needs the cast the inline mocks above get for free from inference.
+		const mockEnv = { ...env, AI: { run: mockRun } } as unknown as Env;
 		const request = new IncomingRequest('http://example.com', {
 			method: 'POST',
 			body: buildForm(content, 'fr', model)


### PR DESCRIPTION
Fixes main, which I left red by merging #39 without gating on its CI result.

`ReturnType<typeof vi.fn>` is wider than the `Ai.run` signature. The inline mocks elsewhere in the file get a narrow enough type from inference; the shared `runWith` helper needs an explicit cast.

Caught by `npx tsc -p test/tsconfig.json --noEmit`, which CI runs as a separate step from the root typecheck and which I had not been running locally. All four CI steps (root typecheck, test typecheck, tests, wrangler dry-run) verified locally before pushing this time.

Because the test job failed, `deploy-staging` never ran — nothing broken reached staging or production.