### PR TITLE
feat: turn the model experiment into a registry of candidates

### DIFF
--- a/scripts/compare-models.mjs
+++ b/scripts/compare-models.mjs
@@ -24,19 +24,20 @@ import { basename } from "node:path";
 const DEFAULT_URL = "https://translatemessages-staging.justblackmagic.workers.dev/";
 const DEFAULT_FIXTURE = new URL("./fixtures/comparison.properties", import.meta.url).pathname;
 const DEFAULT_LANGUAGES = ["fr", "es", "de", "ja"];
-const MODELS = ["m2m100", "llama"];
+// m2m100 first so it reads as the baseline every other column is judged against.
+const DEFAULT_MODELS = ["m2m100", "llama-3.1-8b"];
 
 // Kept in step with PLACEHOLDER_REGEX in src/index.ts. If they drift, this script
 // will happily report a fidelity score that the Worker does not actually enforce.
 const PLACEHOLDER_REGEX = /\{[0-9a-zA-Z_,.#:\s]+\}|\$\{[0-9a-zA-Z_.:-]+\}|%[0-9]*\$?[-+#0-9.]*[a-zA-Z]/g;
 
 function parseArgs(argv) {
-	const args = { url: DEFAULT_URL, file: DEFAULT_FIXTURE, languages: DEFAULT_LANGUAGES, out: null };
+	const args = { url: DEFAULT_URL, file: DEFAULT_FIXTURE, languages: DEFAULT_LANGUAGES, models: DEFAULT_MODELS, out: null };
 	for (let i = 0; i < argv.length; i += 2) {
 		const key = argv[i]?.replace(/^--/, "");
 		const value = argv[i + 1];
 		if (!key || value === undefined) continue;
-		if (key === "languages") args.languages = value.split(",").map(entry => entry.trim()).filter(Boolean);
+		if (key === "languages" || key === "models") args[key] = value.split(",").map(entry => entry.trim()).filter(Boolean);
 		else if (key in args) args[key] = value;
 	}
 	return args;
@@ -150,9 +151,9 @@ function score(sourceEntries, result) {
 	};
 }
 
-function renderReport({ fixture, url, languages, results }) {
+function renderReport({ fixture, url, languages, models, results }) {
 	const lines = [];
-	lines.push(`# Model comparison: m2m100 vs llama`, "");
+	lines.push(`# Model comparison: ${models.join(" vs ")}`, "");
 	lines.push(`Fixture: \`${basename(fixture)}\` · Endpoint: \`${url}\``, "");
 
 	lines.push(`## Summary`, "");
@@ -161,7 +162,7 @@ function renderReport({ fixture, url, languages, results }) {
 	lines.push(`|---|---|---|---|---|---|---|---|`);
 
 	for (const language of languages) {
-		for (const model of MODELS) {
+		for (const model of models) {
 			const result = results[language][model];
 			if (result.failed) {
 				lines.push(`| ${language} | ${model} | — | — | — | — | — | HTTP ${result.status} |`);
@@ -179,23 +180,29 @@ function renderReport({ fixture, url, languages, results }) {
 	lines.push(`Read this part. The table above cannot tell you whether a translation is good,`);
 	lines.push(`only whether it is structurally intact.`, "");
 
+	const labelWidth = Math.max(...models.map(model => model.length), 2);
+
 	for (const language of languages) {
-		const m2m = results[language].m2m100;
-		const llama = results[language].llama;
 		lines.push(`### ${language}`, "");
-		if (m2m.failed || llama.failed) {
-			lines.push(`One or both backends failed for this language; see the summary.`, "");
+
+		const usable = models.filter(model => !results[language][model].failed);
+		if (usable.length === 0) {
+			lines.push(`Every backend failed for this language; see the summary.`, "");
 			continue;
 		}
+		if (usable.length < models.length) {
+			const broken = models.filter(model => results[language][model].failed);
+			lines.push(`Omitted (request failed): ${broken.join(", ")}.`, "");
+		}
 
-		for (let i = 0; i < m2m.rows.length; i++) {
-			const source = m2m.rows[i];
-			const llamaRow = llama.rows[i];
-			lines.push(`**\`${source.key}\`**`, "");
+		const rowCount = results[language][usable[0]].rows.length;
+		for (let i = 0; i < rowCount; i++) {
+			lines.push(`**\`${results[language][usable[0]].rows[i].key}\`**`, "");
 			lines.push("```");
-			lines.push(`en     ${source.value}`);
-			lines.push(`m2m    ${formatCell(source)}`);
-			lines.push(`llama  ${formatCell(llamaRow)}`);
+			lines.push(`${"en".padEnd(labelWidth)}  ${results[language][usable[0]].rows[i].value}`);
+			for (const model of usable) {
+				lines.push(`${model.padEnd(labelWidth)}  ${formatCell(results[language][model].rows[i])}`);
+			}
 			lines.push("```", "");
 		}
 	}
@@ -216,14 +223,14 @@ async function main() {
 	const content = await readFile(args.file, "utf8");
 	const sourceEntries = parseEntries(content);
 
-	console.error(`Comparing ${MODELS.join(" vs ")} on ${sourceEntries.length} entries across ${args.languages.join(", ")}`);
+	console.error(`Comparing ${args.models.join(" vs ")} on ${sourceEntries.length} entries across ${args.languages.join(", ")}`);
 	console.error(`Endpoint: ${args.url}`);
 
 	const results = {};
 	for (const language of args.languages) {
 		results[language] = {};
 		// Sequential on purpose: concurrent runs would make the latency column noise.
-		for (const model of MODELS) {
+		for (const model of args.models) {
 			process.stderr.write(`  ${language}/${model} ... `);
 			const result = await translate({ url: args.url, content, language, model });
 			results[language][model] = score(sourceEntries, result);
@@ -231,7 +238,7 @@ async function main() {
 		}
 	}
 
-	const report = renderReport({ fixture: args.file, url: args.url, languages: args.languages, results });
+	const report = renderReport({ fixture: args.file, url: args.url, languages: args.languages, models: args.models, results });
 	if (args.out) {
 		await writeFile(args.out, report, "utf8");
 		console.error(`\nWrote ${args.out}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,16 +54,35 @@ const SEGMENT_DELIMITER = "__SEG__";
 const PLACEHOLDER_MARKER_PREFIX = "XQZ";
 
 // Translation backends. m2m100 is the default and the only one the frontend uses;
-// llama is opt-in via the `model` form field so its output quality can be compared
-// against m2m100 on the same input. It needs no placeholder masking, which is the
-// hypothesis being tested -- see PLACEHOLDER_MARKER_PREFIX for why masking is
-// fragile against a model that rewrites rare tokens.
-const M2M_MODEL = "@cf/meta/m2m100-1.2b";
-const LLAMA_MODEL = "@cf/meta/llama-3-8b-instruct-awq";
+// the rest are opt-in via the `model` form field so their output can be compared
+// against m2m100 on identical input. See PLACEHOLDER_MARKER_PREFIX for why masking
+// is fragile against a model that rewrites rare tokens -- avoiding it is the point.
+//
+// A registry rather than a single alternative, because Workers AI retires models on
+// its own schedule -- llama-3-8b-instruct-awq was deprecated out from under this
+// experiment mid-flight, and the generated types still list it. Candidates are named
+// independently of their model IDs so a retirement is a one-line swap.
+//
+// "seq2seq" models translate text directly and need placeholders masked behind
+// markers. "instruct" models are told to copy placeholders verbatim, which is the
+// hypothesis this registry exists to test.
+const TRANSLATION_MODELS = {
+	"m2m100": { id: "@cf/meta/m2m100-1.2b", kind: "seq2seq" },
+	"llama-3.1-8b": { id: "@cf/meta/llama-3.1-8b-instruct-fp8", kind: "instruct" },
+	"llama-3.2-3b": { id: "@cf/meta/llama-3.2-3b-instruct", kind: "instruct" },
+	"llama-3.3-70b": { id: "@cf/meta/llama-3.3-70b-instruct-fp8-fast", kind: "instruct" },
+	"llama-4-scout": { id: "@cf/meta/llama-4-scout-17b-16e-instruct", kind: "instruct" },
+	"gemma-3-12b": { id: "@cf/google/gemma-3-12b-it", kind: "instruct" },
+	"mistral-small-3.1": { id: "@cf/mistralai/mistral-small-3.1-24b-instruct", kind: "instruct" }
+} as const;
 
-export type ModelChoice = "m2m100" | "llama";
-export const MODEL_CHOICES: ModelChoice[] = ["m2m100", "llama"];
+export type ModelChoice = keyof typeof TRANSLATION_MODELS;
+export const MODEL_CHOICES = Object.keys(TRANSLATION_MODELS) as ModelChoice[];
 const DEFAULT_MODEL: ModelChoice = "m2m100";
+
+function usesInstructPrompting(model: ModelChoice): boolean {
+	return TRANSLATION_MODELS[model].kind === "instruct";
+}
 
 // m2m100 degenerates on very short inputs: "Hi XQZ0" comes back with the marker
 // dropped entirely, while "Hi XQZ0." translates correctly and keeps it. Measured
@@ -292,12 +311,12 @@ async function translateMessages(text: string, targetLanguage: string, env: Env,
 
 async function translateText(text: string, targetLanguage: string, env: Env, model: ModelChoice): Promise<string> {
 	try {
-		if (model === "llama") {
-			return await translateWithInstructModel(text, targetLanguage, env);
+		if (usesInstructPrompting(model)) {
+			return await translateWithInstructModel(text, targetLanguage, env, model);
 		}
 
 		const response = await env.AI.run(
-			M2M_MODEL,
+			TRANSLATION_MODELS[model].id,
 			{
 				text: text,
 				source_lang: "en",
@@ -320,9 +339,14 @@ async function translateText(text: string, targetLanguage: string, env: Env, mod
 // unchanged. An instruction-following model needs no placeholder masking -- it is
 // told to copy placeholders verbatim and the result is verified the same way the
 // masked path is -- which is the whole point of the comparison.
-async function translateWithInstructModel(text: string, targetLanguage: string, env: Env): Promise<string> {
+async function translateWithInstructModel(
+	text: string,
+	targetLanguage: string,
+	env: Env,
+	model: ModelChoice
+): Promise<string> {
 	const response = await env.AI.run(
-		LLAMA_MODEL,
+		TRANSLATION_MODELS[model].id,
 		{
 			messages: [
 				{ role: "system", content: instructSystemPrompt(targetLanguage) },
@@ -453,7 +477,7 @@ async function translateEntry(lines: string[], targetLanguage: string, env: Env,
 	}
 
 	const placeholderCounter = { current: 0 };
-	const maskedSegments = unescapedValues.map(value => maskPlaceholders(value, placeholderCounter, model !== "llama"));
+	const maskedSegments = unescapedValues.map(value => maskPlaceholders(value, placeholderCounter, !usesInstructPrompting(model)));
 	// A trailing space keeps the delimiter from fusing to the following word, which
 	// left that word untranslated. Continuation values already end with a space
 	// before their backslash, so the left-hand side needs no padding.

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -844,13 +844,13 @@ describe('llama backend (experimental)', () => {
 	it('sends placeholders unmasked and keeps them in the output', async () => {
 		const mockRun = vi.fn().mockResolvedValue({ response: 'Bonjour {0}' });
 
-		const response = await runWith(mockRun, "greeting=Hello {0}\n", 'llama');
+		const response = await runWith(mockRun, "greeting=Hello {0}\n", 'llama-3.1-8b');
 
 		expect(response.status).toBe(200);
 		expect(await response.text()).toBe("greeting=Bonjour {0}\n");
 
 		const [modelId, args] = mockRun.mock.calls[0];
-		expect(modelId).toBe('@cf/meta/llama-3-8b-instruct-awq');
+		expect(modelId).toBe('@cf/meta/llama-3.1-8b-instruct-fp8');
 		// The whole hypothesis: the model sees the real placeholder, not a marker.
 		expect(args.messages[1].content).toBe('Hello {0}');
 		expect(args.messages[0].content).toContain('{0}');
@@ -877,7 +877,7 @@ describe('llama backend (experimental)', () => {
 	it('fails the entry when the model drops a placeholder', async () => {
 		const mockRun = vi.fn().mockResolvedValue({ response: 'Bonjour' });
 
-		const response = await runWith(mockRun, "greeting=Hello {0}\n", 'llama');
+		const response = await runWith(mockRun, "greeting=Hello {0}\n", 'llama-3.1-8b');
 
 		// Same contract as the masked path: never ship a value with a placeholder
 		// silently missing.
@@ -889,7 +889,7 @@ describe('llama backend (experimental)', () => {
 	it('fails the entry when a repeated placeholder comes back only once', async () => {
 		const mockRun = vi.fn().mockResolvedValue({ response: 'Bonjour {0}' });
 
-		const response = await runWith(mockRun, "greeting=Hello {0} and {0}\n", 'llama');
+		const response = await runWith(mockRun, "greeting=Hello {0} and {0}\n", 'llama-3.1-8b');
 
 		expect(await response.text()).toBe("greeting=Hello {0} and {0}\n");
 		expect(response.headers.get('X-Translation-Failures')).toBe('1');
@@ -898,7 +898,7 @@ describe('llama backend (experimental)', () => {
 	it('strips conversational scaffolding from the reply', async () => {
 		const mockRun = vi.fn().mockResolvedValue({ response: '  Translation: "Bonjour {0}"  ' });
 
-		const response = await runWith(mockRun, "greeting=Hello {0}\n", 'llama');
+		const response = await runWith(mockRun, "greeting=Hello {0}\n", 'llama-3.1-8b');
 
 		expect(await response.text()).toBe("greeting=Bonjour {0}\n");
 	});
@@ -906,7 +906,7 @@ describe('llama backend (experimental)', () => {
 	it('leaves quotes that belong to the string alone', async () => {
 		const mockRun = vi.fn().mockResolvedValue({ response: 'Il a dit "bonjour" {0}' });
 
-		const response = await runWith(mockRun, "greeting=He said \"hello\" {0}\n", 'llama');
+		const response = await runWith(mockRun, "greeting=He said \"hello\" {0}\n", 'llama-3.1-8b');
 
 		expect(await response.text()).toBe("greeting=Il a dit \"bonjour\" {0}\n");
 	});


### PR DESCRIPTION
`llama-3-8b-instruct-awq` was deprecated on 2026-05-30 and now returns `5028: This model was deprecated`. That surfaced only when the harness ran against staging — the generated `worker-configuration.d.ts` still lists it, so the types gave no warning.

Betting the experiment on one hardcoded alternative was the mistake. This replaces it with a registry:

- Candidates are named independently of their model IDs, so a retirement is a one-line swap.
- Each carries a `kind`: `seq2seq` needs placeholder masking, `instruct` is told to copy placeholders verbatim. That flag drives the masking decision instead of a hardcoded model name.
- Candidates: `llama-3.1-8b`, `llama-3.2-3b`, `llama-3.3-70b`, `llama-4-scout`, `gemma-3-12b`, `mistral-small-3.1`. Which are still live is an empirical question the harness now answers.

`compare-models.mjs` takes `--models` so any subset can be compared in one run, and the side-by-side renders N columns rather than exactly two.

All four CI checks verified locally before pushing.