### PR TITLE
docs: record the model comparison baseline and what it actually showed

### DIFF
--- a/docs/model-comparison/README.md
+++ b/docs/model-comparison/README.md
@@ -1,0 +1,95 @@
+# Model comparison: m2m100 vs instruction-following models
+
+Baseline measurements taken 2026-07-27 against the deployed staging Worker, using
+`scripts/compare-models.mjs` and `scripts/fixtures/comparison.properties` (25 entries).
+
+Regenerate with:
+
+```bash
+node scripts/compare-models.mjs --models m2m100,llama-3.1-8b,llama-4-scout --languages fr,ja
+```
+
+## Conclusion
+
+**Instruction-following models are clearly better on high-resource languages and
+should not be adopted for the full supported-language list without further work.**
+Two defect classes found in the low-resource sweep are not yet guarded against.
+
+## High-resource languages (fr, es, de, ja)
+
+[Full report](./high-resource-2026-07-27.md)
+
+Placeholders lost: **0 across all 600 translations**, every model. Structural
+integrity is no longer what separates them; wording quality is.
+
+| Model | Translated (of 100) | Failures | Latency |
+|---|---|---|---|
+| m2m100 (current default) | 95 | 1 | 2.2–6.6s |
+| llama-3.1-8b | 100 | 0 | ~2.3s |
+| llama-3.2-3b | 89 | 9 | 0.7–0.9s |
+| llama-3.3-70b | 97 | 0 | 1.6–4.1s |
+| llama-4-scout | 98 | 0 | ~1.2s |
+| mistral-small-3.1 | 99 | 0 | 1.9–3.2s |
+
+m2m100 is weakest exactly where a `messages.properties` file lives — short UI
+strings:
+
+- `Save` → `Sauvons` (fr, "let us save") and `Rettung` (de, "rescue"), where the
+  instruct models give `Enregistrer` / `Speichern`.
+- `Task Manager` and `Hi {0}` left untranslated in German.
+- `First line\nSecond line` → `Erste Linie\nZZ Zweite Linie` (de): "Linie" is a
+  geometric line rather than a line of text, and `ZZ` is marker debris that survived
+  verification because the marker itself was intact.
+
+## Low-resource languages (ff, ilo, ns, wo, ast, am)
+
+[Full report](./low-resource-2026-07-27.md)
+
+The headline numbers favour the instruct models — llama-4-scout scored 144/150
+"translated" against m2m100's 101/150 — **but that column is misleading here and
+should not be read as a quality result.** It only measures whether the output
+differs from the English source, which confidently wrong output also satisfies.
+
+Spot-checking found both approaches unusable:
+
+- m2m100, Fulah `Welcome to your dashboard` → `Mo Di Mi Do Fr Sa So` (German weekday
+  abbreviations). Wolof → `Lees meer »` (Dutch).
+- llama-4-scout, Fulah `Hello {0}` → `Bonjour {0}` and Wolof `Save` → `Sauvegarder`.
+  Both French.
+
+m2m100 frequently echoes the English instead, which is at least visibly untranslated.
+The instruct models fail silently, which is worse for a file destined for production.
+
+### Two defects this surfaced
+
+Neither is currently guarded against. Both affect the instruct path only, which is
+opt-in and not reachable from the frontend.
+
+1. **Hallucinated placeholders.** `app.welcome` has no placeholder in the source, and
+   llama-4-scout returned `Welcoming ngal laawol ɗuniyaarum {0}`. Verification checks
+   that every source placeholder survives; nothing rejects placeholders the model
+   invented. A literal `{0}` in a Spring message is a production bug.
+
+2. **Leaked commentary.** llama-3.1-8b returned
+   `Saw\n\n(No change, as "Save" is a single word)` as the value.
+   `cleanInstructOutput` strips leading labels and wrapping quotes, but not a
+   parenthetical note appended after a blank line.
+
+## If this is adopted
+
+1. Reject outputs containing placeholders absent from the source.
+2. Reject multi-line or parenthetical commentary in a single-line value.
+3. Restrict the instruct path to languages where it has been measured, and keep
+   m2m100 — or refuse the request — elsewhere.
+4. Batch multiple entries per call. This is where the cost advantage is, and only an
+   instruction-following model can do it; m2m100 is one call per entry by
+   construction. Prototyped unbatched on purpose, so the model was the only variable.
+
+## Cost
+
+Not settled. `llama-3-8b-instruct-awq`, the original candidate, was deprecated on
+2026-05-30 and now returns error 5028 — the generated `worker-configuration.d.ts`
+still lists it, so the types gave no warning. Cloudflare's docs do not publish unit
+pricing for the exact IDs that work today (`llama-3.1-8b-instruct-fp8`,
+`llama-4-scout-17b-16e-instruct`, `mistral-small-3.1-24b-instruct`), so read those
+off the dashboard rather than extrapolating from the non-fp8 variants.

--- a/docs/model-comparison/high-resource-2026-07-27.md
+++ b/docs/model-comparison/high-resource-2026-07-27.md
@@ -1,0 +1,1247 @@
+# Model comparison: m2m100 vs llama-3.1-8b vs llama-3.2-3b vs llama-3.3-70b vs llama-4-scout vs mistral-small-3.1
+
+Fixture: `comparison.properties` · Endpoint: `https://translatemessages-staging.justblackmagic.workers.dev/`
+
+## Summary
+
+Lower is better for every column except "translated".
+
+| Language | Model | Translated | Unchanged | Placeholders lost | Reported failures | Missing keys | Latency |
+|---|---|---|---|---|---|---|---|
+| fr | m2m100 | 25/25 | 0 | 0 | 0 | 0 | 6644ms |
+| fr | llama-3.1-8b | 25/25 | 0 | 0 | 0 | 0 | 2173ms |
+| fr | llama-3.2-3b | 24/25 | 1 | 0 | 1 | 0 | 865ms |
+| fr | llama-3.3-70b | 24/25 | 1 | 0 | 0 | 0 | 1648ms |
+| fr | llama-4-scout | 25/25 | 0 | 0 | 0 | 0 | 1229ms |
+| fr | mistral-small-3.1 | 25/25 | 0 | 0 | 0 | 0 | 1879ms |
+| es | m2m100 | 25/25 | 0 | 0 | 0 | 0 | 2682ms |
+| es | llama-3.1-8b | 25/25 | 0 | 0 | 0 | 0 | 2416ms |
+| es | llama-3.2-3b | 22/25 | 3 | 0 | 3 | 0 | 666ms |
+| es | llama-3.3-70b | 25/25 | 0 | 0 | 0 | 0 | 2807ms |
+| es | llama-4-scout | 25/25 | 0 | 0 | 0 | 0 | 946ms |
+| es | mistral-small-3.1 | 25/25 | 0 | 0 | 0 | 0 | 1990ms |
+| de | m2m100 | 23/25 | 2 | 0 | 0 | 0 | 4518ms |
+| de | llama-3.1-8b | 25/25 | 0 | 0 | 0 | 0 | 2462ms |
+| de | llama-3.2-3b | 23/25 | 2 | 0 | 2 | 0 | 767ms |
+| de | llama-3.3-70b | 24/25 | 1 | 0 | 0 | 0 | 1562ms |
+| de | llama-4-scout | 24/25 | 1 | 0 | 0 | 0 | 1175ms |
+| de | mistral-small-3.1 | 25/25 | 0 | 0 | 0 | 0 | 2697ms |
+| ja | m2m100 | 22/25 | 3 | 0 | 1 | 0 | 2208ms |
+| ja | llama-3.1-8b | 25/25 | 0 | 0 | 0 | 0 | 2227ms |
+| ja | llama-3.2-3b | 20/25 | 5 | 0 | 3 | 0 | 758ms |
+| ja | llama-3.3-70b | 24/25 | 1 | 0 | 0 | 0 | 4117ms |
+| ja | llama-4-scout | 24/25 | 1 | 0 | 0 | 0 | 1506ms |
+| ja | mistral-small-3.1 | 24/25 | 1 | 0 | 0 | 0 | 3190ms |
+
+## Side by side
+
+Read this part. The table above cannot tell you whether a translation is good,
+only whether it is structurally intact.
+
+### fr
+
+**`app.name`**
+
+```
+en                 Task Manager
+m2m100             Gestionnaire de t\u00e2ches
+llama-3.1-8b       Gestionnaire de t\u00e2ches
+llama-3.2-3b       Gestionnaire de t\u00e2ches
+llama-3.3-70b      Gestionnaire de t\u00e2ches
+llama-4-scout      Gestionnaire de t\u00e2ches
+mistral-small-3.1  Gestionnaire des t\u00e2ches
+```
+
+**`app.welcome`**
+
+```
+en                 Welcome to your dashboard
+m2m100             Bienvenue sur votre dashboard
+llama-3.1-8b       Bienvenue sur votre tableau de bord
+llama-3.2-3b       Bienvenue sur votre tableau de bord
+llama-3.3-70b      Bienvenue sur votre tableau de bord
+llama-4-scout      Bienvenue sur votre tableau de bord
+mistral-small-3.1  Bienvenue sur votre tableau de bord
+```
+
+**`app.description`**
+
+```
+en                 Manage your projects and collaborate with your team in one place
+m2m100             G\u00e9rer vos projets et collaborer avec votre \u00e9quipe en un seul endroit
+llama-3.1-8b       G\u00e9rer vos projets et collaborer avec votre \u00e9quipe dans un seul endroit
+llama-3.2-3b       G\u00e9rer vos projets et collaborer avec votre \u00e9quipe dans un seul endroit
+llama-3.3-70b      G\u00e9rez vos projets et collaborez avec votre \u00e9quipe en un seul endroit
+llama-4-scout      G\u00e9rez vos projets et collaborez avec votre \u00e9quipe en un seul endroit
+mistral-small-3.1  G\u00e9rez vos projets et collaborez avec votre \u00e9quipe en un seul endroit
+```
+
+**`button.ok`**
+
+```
+en                 OK
+m2m100             OK \u00e0
+llama-3.1-8b       D'accord
+llama-3.2-3b       d'accord
+llama-3.3-70b      OK   <-- UNCHANGED
+llama-4-scout      D'accord
+mistral-small-3.1  D'accord
+```
+
+**`button.save`**
+
+```
+en                 Save
+m2m100             Sauvons
+llama-3.1-8b       Sauvegarder
+llama-3.2-3b       Enregistrer
+llama-3.3-70b      Enregistrer
+llama-4-scout      Enregistrer
+mistral-small-3.1  Enregistrer
+```
+
+**`label.hi`**
+
+```
+en                 Hi {0}
+m2m100             Bonjour {0}
+llama-3.1-8b       Bonjour {0}
+llama-3.2-3b       Bonjour {0}
+llama-3.3-70b      Bonjour {0}
+llama-4-scout      Bonjour {0}
+mistral-small-3.1  Bonjour {0}
+```
+
+**`label.bye`**
+
+```
+en                 Bye {0}
+m2m100             Au revoir {0}
+llama-3.1-8b       Au revoir {0}
+llama-3.2-3b       Au revoir {0}
+llama-3.3-70b      Au revoir {0}
+llama-4-scout      Au revoir {0}
+mistral-small-3.1  Au revoir {0}
+```
+
+**`message.greeting`**
+
+```
+en                 Hello {0}
+m2m100             Bonjour {0}
+llama-3.1-8b       Bonjour {0}
+llama-3.2-3b       Bonjour {0}
+llama-3.3-70b      Bonjour {0}
+llama-4-scout      Bonjour {0}
+mistral-small-3.1  Bonjour {0}
+```
+
+**`message.count`**
+
+```
+en                 You have {0} of {1} messages
+m2m100             Vous avez {0} de messages {1}
+llama-3.1-8b       Vous avez {0} de {1} messages
+llama-3.2-3b       Vous avez {0} de {1} messages
+llama-3.3-70b      Vous avez {0} sur {1} messages
+llama-4-scout      Vous avez {0} sur {1} messages
+mistral-small-3.1  Vous avez {0} sur {1} messages
+```
+
+**`message.repeat`**
+
+```
+en                 Hello {0}, we said hello {0} already
+m2m100             Bonjour {0}, nous avons d\u00e9j\u00e0 dit bonjour {0}
+llama-3.1-8b       Bonjour {0}, nous avons d\u00e9j\u00e0 dit bonjour {0}
+llama-3.2-3b       Bonjour {0}, nous avons d\u00e9j\u00e0 dit bonjour {0}.
+llama-3.3-70b      Bonjour {0}, nous avons d\u00e9j\u00e0 dit bonjour {0}
+llama-4-scout      Bonjour {0}, nous avons d\u00e9j\u00e0 dit bonjour {0}
+mistral-small-3.1  Bonjour {0}, nous avons d\u00e9j\u00e0 dit bonjour {0}
+```
+
+**`message.order`**
+
+```
+en                 {0} items shipped to {1} on {2}
+m2m100             {0} articles exp\u00e9di\u00e9s \u00e0 {1} sur {2}
+llama-3.1-8b       {0} articles exp\u00e9di\u00e9s \u00e0 {1} le {2}
+llama-3.2-3b       {0} items shipped to {1} on {2}   <-- UNCHANGED
+llama-3.3-70b      {0} articles exp\u00e9di\u00e9s \u00e0 {1} le {2}
+llama-4-scout      {0} articles exp\u00e9di\u00e9s \u00e0 {1} le {2}
+mistral-small-3.1  {0} articles exp\u00e9di\u00e9s \u00e0 {1} le {2}
+```
+
+**`user.welcome`**
+
+```
+en                 Welcome back, ${name}
+m2m100             Bienvenue \u00e0 nouveau, ${name}
+llama-3.1-8b       Bienvenue de retour, ${name}
+llama-3.2-3b       Bienvenue \u00e0 nouveau, ${name}
+llama-3.3-70b      Bienvenue, ${name}
+llama-4-scout      Bienvenue en arri\u00e8re, ${name}
+mistral-small-3.1  Bienvenue \u00e0 nouveau, ${name}
+```
+
+**`user.profile`**
+
+```
+en                 Profile for ${user.name} in ${user.role}
+m2m100             Profil pour ${user.name} en ${user.role}
+llama-3.1-8b       Profil pour ${user.name} dans ${user.role}
+llama-3.2-3b       Profile pour ${user.name} en ${user.role}
+llama-3.3-70b      Profil pour ${user.name} en ${user.role}
+llama-4-scout      Profil pour ${user.name} dans ${user.role}
+mistral-small-3.1  Profil pour ${user.name} dans le r\u00f4le ${user.role}
+```
+
+**`stats.total`**
+
+```
+en                 Total: %s items
+m2m100             Total \: %s articles
+llama-3.1-8b       Total \: %s articles
+llama-3.2-3b       Total \: %s items
+llama-3.3-70b      Total \: %s \u00e9l\u00e9ments
+llama-4-scout      Total \: %s articles
+mistral-small-3.1  Total\u00a0\: %s articles
+```
+
+**`stats.indexed`**
+
+```
+en                 %1$s scored %2$d points
+m2m100             %1$s marqu\u00e9 %2$d points
+llama-3.1-8b       %1$s a marqu\u00e9 %2$d points
+llama-3.2-3b       %1$s a marqu\u00e9 %2$d points
+llama-3.3-70b      %1$s a marqu\u00e9 %2$d points
+llama-4-scout      %1$s a obtenu %2$d points
+mistral-small-3.1  %1$s a marqu\u00e9 %2$d points
+```
+
+**`alert.warning`**
+
+```
+en                 Warning, {0}!
+m2m100             Avertissement {0} \!
+llama-3.1-8b       Attention, {0} \!
+llama-3.2-3b       Attention, {0} \!
+llama-3.3-70b      Avertissement, {0} \!
+llama-4-scout      Avertissement, {0} \!
+mistral-small-3.1  Attention, {0}\!
+```
+
+**`alert.question`**
+
+```
+en                 Are you sure you want to delete {0}?
+m2m100             \u00cates-vous s\u00fbr que vous voulez supprimer {0}?
+llama-3.1-8b       Voulez-vous vraiment supprimer {0} ?
+llama-3.2-3b       {0}
+llama-3.3-70b      \u00cates-vous s\u00fbr de vouloir supprimer {0} ?
+llama-4-scout      \u00cates-vous s\u00fbr de vouloir supprimer {0} ?
+mistral-small-3.1  \u00cates-vous s\u00fbr de vouloir supprimer {0} ?
+```
+
+**`alert.parens`**
+
+```
+en                 Order ({0}) has shipped
+m2m100             La commande ({0}) a \u00e9t\u00e9 exp\u00e9di\u00e9e
+llama-3.1-8b       Commande ({0}) a \u00e9t\u00e9 exp\u00e9di\u00e9e
+llama-3.2-3b       L'ordre ({0}) a \u00e9t\u00e9 exp\u00e9di\u00e9
+llama-3.3-70b      Commande ({0}) a \u00e9t\u00e9 exp\u00e9di\u00e9e
+llama-4-scout      La commande ({0}) a \u00e9t\u00e9 exp\u00e9di\u00e9e
+mistral-small-3.1  Commande ({0}) a \u00e9t\u00e9 exp\u00e9di\u00e9e
+```
+
+**`help.multiline`**
+
+```
+en                 First line\nSecond line
+m2m100             Premi\u00e8re ligne\nSeconde ligne
+llama-3.1-8b       Premi\u00e8re ligne\nDeuxi\u00e8me ligne
+llama-3.2-3b       Premi\u00e8re ligne\nDeuxi\u00e8me ligne
+llama-3.3-70b      Premi\u00e8re ligne\nDeuxi\u00e8me ligne
+llama-4-scout      Premi\u00e8re ligne\nDeuxi\u00e8me ligne
+mistral-small-3.1  Premi\u00e8re ligne\nDeuxi\u00e8me ligne
+```
+
+**`help.tabbed`**
+
+```
+en                 Column one\tColumn two
+m2m100             Colonne une\tColonne deux
+llama-3.1-8b       Colonnes un\tColonnes deux
+llama-3.2-3b       Colonne un\tColonne deux
+llama-3.3-70b      Colonne un\tColonne deux
+llama-4-scout      Colonne un\tColonne deux
+mistral-small-3.1  Colonne une\tColonne deux
+```
+
+**`help.unicode`**
+
+```
+en                 Café près de l’hôtel
+m2m100             Caf\u00e9 pr\u00e8s de l'h\u00f4tel
+llama-3.1-8b       Caf\u00e9 pr\u00e8s de l'h\u00f4tel
+llama-3.2-3b       Caf\u00e9 pr\u00e8s de l'h\u00f4tel
+llama-3.3-70b      Caf\u00e9 pr\u00e8s de l'h\u00f4tel
+llama-4-scout      Caf\u00e9 near the hotel -> Caf\u00e9 pr\u00e8s de l'h\u00f4tel \n Caf\u00e9 -> Caf\u00e9 \n near -> pr\u00e8s de \n the -> l' \n hotel -> h\u00f4tel \nCaf\u00e9 pr\u00e8s de l'h\u00f4tel
+mistral-small-3.1  Caf\u00e9 pr\u00e8s de l'h\u00f4tel
+```
+
+**`terms.long`**
+
+```
+en                 By continuing you agree to the terms {0} and the privacy policy {1} effective today
+m2m100             En continuant, vous acceptez les termes {0} et la politique de confidentialit\u00e9 {1} en vigueur aujourd'hui
+llama-3.1-8b       En continuant, vous acceptez les termes {0} et la politique de confidentialit\u00e9 {1} en vigueur aujourd'hui
+llama-3.2-3b       En continuant, vous acceptez les termes {0} et la politique de confidentialit\u00e9 {1} applicable \u00e0 partir aujourd'hui
+llama-3.3-70b      En continuant, vous acceptez les conditions {0} et la politique de confidentialit\u00e9 {1} en vigueur aujourd'hui
+llama-4-scout      En poursuivant, vous acceptez les conditions {0} et la politique de confidentialit\u00e9 {1} en vigueur aujourd'hui
+mistral-small-3.1  En continuant, vous acceptez les conditions {0} et la politique de confidentialit\u00e9 {1} en vigueur \u00e0 partir d'aujourd'hui
+```
+
+**`footer.copyright`**
+
+```
+en                 All rights reserved  # do not translate the year
+m2m100             Tous droits r\u00e9serv\u00e9s  # do not translate the year
+llama-3.1-8b       Tous droits r\u00e9serv\u00e9s  # do not translate the year
+llama-3.2-3b       Tous droits r\u00e9serv\u00e9s  # do not translate the year
+llama-3.3-70b      Tous droits r\u00e9serv\u00e9s  # do not translate the year
+llama-4-scout      Tous droits r\u00e9serv\u00e9s  # do not translate the year
+mistral-small-3.1  Tous droits r\u00e9serv\u00e9s  # do not translate the year
+```
+
+**`error.permission`**
+
+```
+en                 You do not have permission to perform this action. Contact your administrator if you believe this is a mistake.
+m2m100             Vous n'avez pas l'autorisation d'effectuer cette action. Contactez votre administrateur si vous pensez que c'est une erreur.
+llama-3.1-8b       Vous n'avez pas la permission d'ex\u00e9cuter cette action. Contactez votre administrateur si vous pensez que c'est une erreur.
+llama-3.2-3b       {0}Vous n'avez pas les droits n\u00e9cessaires pour effectuer cette action. Contactez votre administrateur si vous pensez qu'il s'agit d'un erreur.
+llama-3.3-70b      Vous n'avez pas la permission d'effectuer cette action. Contactez votre administrateur si vous pensez qu'il s'agit d'une erreur.
+llama-4-scout      Vous n'avez pas la permission d'effectuer cette action. Contactez votre administrateur si vous pensez que c'est une erreur.
+mistral-small-3.1  Vous n'avez pas la permission d'effectuer cette action. Contactez votre administrateur si vous pensez qu'il s'agit d'une erreur.
+```
+
+**`onboarding.step`**
+
+```
+en                 Choose a workspace name. You can change it later in settings.
+m2m100             Choisissez un nom d'espace de travail. Vous pouvez le modifier plus tard dans les param\u00e8tres.
+llama-3.1-8b       Choisissez un nom de bureau. Vous pouvez le modifier ult\u00e9rieurement dans les param\u00e8tres.
+llama-3.2-3b       Nom du nom de l'espace de travail.
+llama-3.3-70b      Choisissez un nom d'espace de travail. Vous pouvez le modifier plus tard dans les param\u00e8tres.
+llama-4-scout      Choisissez un nom d'espace de travail. Vous pouvez le modifier plus tard dans les param\u00e8tres.
+mistral-small-3.1  Choisissez un nom d'espace de travail. Vous pouvez le modifier plus tard dans les param\u00e8tres.
+```
+
+### es
+
+**`app.name`**
+
+```
+en                 Task Manager
+m2m100             Gerente de tareas
+llama-3.1-8b       Administrador de Tareas
+llama-3.2-3b       Administrador de tareas
+llama-3.3-70b      Administrador de tareas
+llama-4-scout      Administrador de tareas
+mistral-small-3.1  Gestor de tareas
+```
+
+**`app.welcome`**
+
+```
+en                 Welcome to your dashboard
+m2m100             Bienvenido a tu dashboard
+llama-3.1-8b       Bienvenido a su panel de control
+llama-3.2-3b       Bienvenido a su panel de control
+llama-3.3-70b      Bienvenido a tu panel de control
+llama-4-scout      Bienvenido a su panel de control
+mistral-small-3.1  Bienvenido a su panel de control
+```
+
+**`app.description`**
+
+```
+en                 Manage your projects and collaborate with your team in one place
+m2m100             Gestiona tus proyectos y colabora con tu equipo en un solo lugar
+llama-3.1-8b       Administre sus proyectos y colabore con su equipo en un solo lugar
+llama-3.2-3b       Gestiona tus proyectos y colabora con tu equipo en un lugar
+llama-3.3-70b      Administra tus proyectos y colabora con tu equipo en un solo lugar
+llama-4-scout      Gestiona tus proyectos y colabora con tu equipo en un solo lugar
+mistral-small-3.1  Gestiona tus proyectos y colabora con tu equipo en un solo lugar
+```
+
+**`button.ok`**
+
+```
+en                 OK
+m2m100             bien
+llama-3.1-8b       \u00a1De acuerdo
+llama-3.2-3b       ok
+llama-3.3-70b      De acuerdo
+llama-4-scout      Bien
+mistral-small-3.1  Aceptar
+```
+
+**`button.save`**
+
+```
+en                 Save
+m2m100             Salvar
+llama-3.1-8b       Guardar
+llama-3.2-3b       guardar
+llama-3.3-70b      Guardar
+llama-4-scout      Guardar
+mistral-small-3.1  Guardar
+```
+
+**`label.hi`**
+
+```
+en                 Hi {0}
+m2m100             Hola {0}
+llama-3.1-8b       Hola {0}
+llama-3.2-3b       Hola {0}
+llama-3.3-70b      Hola {0}
+llama-4-scout      Hola {0}
+mistral-small-3.1  Hola {0}
+```
+
+**`label.bye`**
+
+```
+en                 Bye {0}
+m2m100             Adi\u00f3s {0}
+llama-3.1-8b       Adi\u00f3s {0}
+llama-3.2-3b       Adi\u00f3s {0}
+llama-3.3-70b      Adi\u00f3s {0}
+llama-4-scout      Adi\u00f3s {0}
+mistral-small-3.1  Adi\u00f3s {0}
+```
+
+**`message.greeting`**
+
+```
+en                 Hello {0}
+m2m100             Hola {0}
+llama-3.1-8b       Hola {0}
+llama-3.2-3b       Hola {0}
+llama-3.3-70b      Hola {0}
+llama-4-scout      Hola {0}
+mistral-small-3.1  Hola {0}
+```
+
+**`message.count`**
+
+```
+en                 You have {0} of {1} messages
+m2m100             Usted tiene {0} de mensajes de {1}
+llama-3.1-8b       Tienes {0} de {1} mensajes
+llama-3.2-3b       Tienes {0} de {1} mensajes
+llama-3.3-70b      Tienes {0} de {1} mensajes
+llama-4-scout      Tienes {0} de {1} mensajes
+mistral-small-3.1  Tienes {0} de {1} mensajes
+```
+
+**`message.repeat`**
+
+```
+en                 Hello {0}, we said hello {0} already
+m2m100             Hola {0}, ya hemos dicho hello {0}
+llama-3.1-8b       Hola {0}, ya saludamos a {0}
+llama-3.2-3b       Hola {0}, ya dijimos hola {0} ya
+llama-3.3-70b      Hola {0}, ya dijimos hola {0}
+llama-4-scout      Hola {0}, ya nos saludamos {0} anteriormente
+mistral-small-3.1  Hola {0}, ya dijimos hola {0}
+```
+
+**`message.order`**
+
+```
+en                 {0} items shipped to {1} on {2}
+m2m100             {0} art\u00edculos enviados a {1} en {2}
+llama-3.1-8b       {0} art\u00edculos enviados a {1} el {2}
+llama-3.2-3b       {0} art\u00edculos enviados a {1} el {2}
+llama-3.3-70b      {0} art\u00edculos enviados a {1} el {2}
+llama-4-scout      {0} art\u00edculos enviados a {1} el {2}
+mistral-small-3.1  {0} art\u00edculos enviados a {1} el {2}
+```
+
+**`user.welcome`**
+
+```
+en                 Welcome back, ${name}
+m2m100             Bienvenido a ${name}
+llama-3.1-8b       Bienvenido de nuevo, ${name}
+llama-3.2-3b       Bienvenido de vuelta, ${name}
+llama-3.3-70b      Bienvenido de nuevo, ${name}
+llama-4-scout      Bienvenido de nuevo, ${name}
+mistral-small-3.1  Bienvenido de nuevo, ${name}
+```
+
+**`user.profile`**
+
+```
+en                 Profile for ${user.name} in ${user.role}
+m2m100             Perfil para ${user.name} en ${user.role}
+llama-3.1-8b       Perfil para ${user.name} en ${user.role}
+llama-3.2-3b       Perfil para ${user.name} en ${user.role}
+llama-3.3-70b      Perfil para ${user.name} en ${user.role}
+llama-4-scout      Perfil de ${user.name} en ${user.role}
+mistral-small-3.1  Perfil para ${user.name} en ${user.role}
+```
+
+**`stats.total`**
+
+```
+en                 Total: %s items
+m2m100             Total\: %s art\u00edculos
+llama-3.1-8b       Total\: %s \u00edtems
+llama-3.2-3b       Total\: %s art\u00edculos
+llama-3.3-70b      Total\: %s elementos
+llama-4-scout      Total\: %s art\u00edculos
+mistral-small-3.1  Total\: %s art\u00edculos
+```
+
+**`stats.indexed`**
+
+```
+en                 %1$s scored %2$d points
+m2m100             %1$s marcado %2$d puntos
+llama-3.1-8b       %1$s anot\u00f3 %2$d puntos
+llama-3.2-3b       %1$s anot\u00f3 %2$d puntos
+llama-3.3-70b      %1$s anot\u00f3 %2$d puntos
+llama-4-scout      %1$s obtuvo %2$d puntos
+mistral-small-3.1  %1$s anot\u00f3 %2$d puntos
+```
+
+**`alert.warning`**
+
+```
+en                 Warning, {0}!
+m2m100             \u00a1Alerta {0}\!
+llama-3.1-8b       \u00a1Advertencia, {0}\!
+llama-3.2-3b       Advertencia, {0}\!
+llama-3.3-70b      Advertencia, {0}\!
+llama-4-scout      Advertencia, {0}\!
+mistral-small-3.1  \u00a1Advertencia, {0}\!
+```
+
+**`alert.question`**
+
+```
+en                 Are you sure you want to delete {0}?
+m2m100             \u00bfEst\u00e1s seguro de que quieres eliminar {0}?
+llama-3.1-8b       \u00bfEst\u00e1s seguro de que deseas eliminar {0}?
+llama-3.2-3b       Are you sure you want to delete {0}?   <-- UNCHANGED
+llama-3.3-70b      \u00bfEst\u00e1s seguro de que deseas eliminar {0}?
+llama-4-scout      \u00bfEst\u00e1 seguro de que desea eliminar {0}?
+mistral-small-3.1  \u00bfEst\u00e1s seguro de que quieres eliminar {0}?
+```
+
+**`alert.parens`**
+
+```
+en                 Order ({0}) has shipped
+m2m100             Orden ({0}) ha sido enviado
+llama-3.1-8b       Ha sido enviado el ({0})
+llama-3.2-3b       El pedido ({0}) ha sido entregado
+llama-3.3-70b      El pedido ({0}) ha sido enviado
+llama-4-scout      El pedido ({0}) ha sido enviado
+mistral-small-3.1  Pedido ({0}) ha sido enviado
+```
+
+**`help.multiline`**
+
+```
+en                 First line\nSecond line
+m2m100             Primera l\u00ednea\nSegunda l\u00ednea
+llama-3.1-8b       Primera l\u00ednea\nSegunda l\u00ednea
+llama-3.2-3b       First line\nSecond line   <-- UNCHANGED
+llama-3.3-70b      Primera l\u00ednea\nSegunda l\u00ednea
+llama-4-scout      Primera l\u00ednea\nSegunda l\u00ednea
+mistral-small-3.1  Primera l\u00ednea\nSegunda l\u00ednea
+```
+
+**`help.tabbed`**
+
+```
+en                 Column one\tColumn two
+m2m100             Columna uno\tColumna dos
+llama-3.1-8b       Column uno\tColumn dos
+llama-3.2-3b       Column one\tColumn two   <-- UNCHANGED
+llama-3.3-70b      Columna uno\tColumna dos
+llama-4-scout      Columna uno\tColumna dos
+mistral-small-3.1  Columna uno\tColumna dos
+```
+
+**`help.unicode`**
+
+```
+en                 Café près de l’hôtel
+m2m100             Caf\u00e9 cerca del hotel
+llama-3.1-8b       Caf\u00e9 cerca del hotel
+llama-3.2-3b       Caf\u00e9 cerca del hotel
+llama-3.3-70b      Cafeter\u00eda cerca del hotel
+llama-4-scout      Caf\u00e9 cerca del hotel
+mistral-small-3.1  Caf\u00e9 cerca del hotel
+```
+
+**`terms.long`**
+
+```
+en                 By continuing you agree to the terms {0} and the privacy policy {1} effective today
+m2m100             Al continuar aceptas los t\u00e9rminos {0} y la pol\u00edtica de privacidad {1} en vigor hoy
+llama-3.1-8b       Al continuar, usted acepta los t\u00e9rminos {0} y la pol\u00edtica de privacidad {1} efectiva a partir de hoy
+llama-3.2-3b       Al seguir adelante, acepta los t\u00e9rminos {0} y la pol\u00edtica de privacidad {1} efectiva a partir de hoy
+llama-3.3-70b      Al continuar, acepta los t\u00e9rminos {0} y la pol\u00edtica de privacidad {1} efectiva a partir de hoy
+llama-4-scout      Al continuar acepta los t\u00e9rminos {0} y la pol\u00edtica de privacidad {1} vigente hoy
+mistral-small-3.1  Al continuar, acepta los t\u00e9rminos {0} y la pol\u00edtica de privacidad {1} vigente a partir de hoy
+```
+
+**`footer.copyright`**
+
+```
+en                 All rights reserved  # do not translate the year
+m2m100             Todos los derechos reservados  # do not translate the year
+llama-3.1-8b       Todos los derechos reservados  # do not translate the year
+llama-3.2-3b       Todos los derechos reservados  # do not translate the year
+llama-3.3-70b      Todos los derechos reservados  # do not translate the year
+llama-4-scout      Todos los derechos reservados  # do not translate the year
+mistral-small-3.1  Todos los derechos reservados  # do not translate the year
+```
+
+**`error.permission`**
+
+```
+en                 You do not have permission to perform this action. Contact your administrator if you believe this is a mistake.
+m2m100             No tienes permiso para realizar esta acci\u00f3n.Contacta con tu administrador si crees que esto es un error.
+llama-3.1-8b       No tiene permiso para realizar esta acci\u00f3n. Comun\u00edquese con su administrador si cree que esto es un error.
+llama-3.2-3b       No tienes permiso para realizar esta acci\u00f3n. Contacta con tu administrador si crees que esto es un error.
+llama-3.3-70b      No tiene permiso para realizar esta acci\u00f3n. P\u00f3ngase en contacto con su administrador si cree que se trata de un error.
+llama-4-scout      No tiene permiso para realizar esta acci\u00f3n. P\u00f3ngase en contacto con su administrador si cree que se trata de un error.
+mistral-small-3.1  No tiene permiso para realizar esta acci\u00f3n. P\u00f3ngase en contacto con su administrador si cree que esto es un error.
+```
+
+**`onboarding.step`**
+
+```
+en                 Choose a workspace name. You can change it later in settings.
+m2m100             Seleccione un nombre de espacio de trabajo. Puede cambiarlo m\u00e1s adelante en la configuraci\u00f3n.
+llama-3.1-8b       Elige un nombre de espacio de trabajo. Puedes cambiarlo m\u00e1s tarde en ajustes.
+llama-3.2-3b       Nombre del espacio de trabajo. Puedes cambiarlo m\u00e1s adelante en configuraciones.
+llama-3.3-70b      Elige un nombre de espacio de trabajo. Puedes cambiarlo m\u00e1s tarde en la configuraci\u00f3n.
+llama-4-scout      Elige un nombre para el espacio de trabajo. Puedes cambiarlo m\u00e1s tarde en ajustes.
+mistral-small-3.1  Elige un nombre para el espacio de trabajo. Puedes cambiarlo m\u00e1s tarde en la configuraci\u00f3n.
+```
+
+### de
+
+**`app.name`**
+
+```
+en                 Task Manager
+m2m100             Task Manager   <-- UNCHANGED
+llama-3.1-8b       Aufgabenmanager
+llama-3.2-3b       Aufgabenverwaltung
+llama-3.3-70b      Aufgaben-Manager
+llama-4-scout      Aufgaben-Manager
+mistral-small-3.1  Aufgaben-Manager
+```
+
+**`app.welcome`**
+
+```
+en                 Welcome to your dashboard
+m2m100             Willkommen auf Ihrem Dashboard
+llama-3.1-8b       Willkommen zur Ihr Dashboard
+llama-3.2-3b       Willkommen zu Ihrem Dashboard
+llama-3.3-70b      Willkommen auf Ihrem Dashboard
+llama-4-scout      Willkommen auf Ihrem Dashboard
+mistral-small-3.1  Willkommen zu Ihrem Dashboard
+```
+
+**`app.description`**
+
+```
+en                 Manage your projects and collaborate with your team in one place
+m2m100             Verwalten Sie Ihre Projekte und arbeiten Sie mit Ihrem Team an einem Ort zusammen
+llama-3.1-8b       Verwalten Sie Ihre Projekte und arbeiten Sie mit Ihrem Team in einem Ort
+llama-3.2-3b       Verwaltet Sie Ihre Projekte und arbeitet mit Ihrem Team in einem Ort
+llama-3.3-70b      Verwalten Sie Ihre Projekte und arbeiten Sie mit Ihrem Team an einem Ort zusammen
+llama-4-scout      Verwalten Sie Ihre Projekte und arbeiten Sie mit Ihrem Team an einem Ort zusammen
+mistral-small-3.1  Verwalten Sie Ihre Projekte und arbeiten Sie mit Ihrem Team an einem Ort zusammen
+```
+
+**`button.ok`**
+
+```
+en                 OK
+m2m100             OK ist
+llama-3.1-8b       Ja
+llama-3.2-3b       Ja
+llama-3.3-70b      OK   <-- UNCHANGED
+llama-4-scout      OK   <-- UNCHANGED
+mistral-small-3.1  In Ordnung
+```
+
+**`button.save`**
+
+```
+en                 Save
+m2m100             Rettung
+llama-3.1-8b       Speichern
+llama-3.2-3b       Speichern
+llama-3.3-70b      Speichern
+llama-4-scout      Speichern
+mistral-small-3.1  Speichern
+```
+
+**`label.hi`**
+
+```
+en                 Hi {0}
+m2m100             Hi {0}   <-- UNCHANGED
+llama-3.1-8b       Hallo {0}
+llama-3.2-3b       Hallo {0}
+llama-3.3-70b      Hallo {0}
+llama-4-scout      Hallo {0}
+mistral-small-3.1  Hallo {0}
+```
+
+**`label.bye`**
+
+```
+en                 Bye {0}
+m2m100             Abschied von {0}
+llama-3.1-8b       Auf Wiedersehen {0}
+llama-3.2-3b       Auf Wiedersehen {0}
+llama-3.3-70b      Tsch\u00fcss {0}
+llama-4-scout      Auf Wiedersehen {0}
+mistral-small-3.1  Tsch\u00fcss {0}
+```
+
+**`message.greeting`**
+
+```
+en                 Hello {0}
+m2m100             Hallo {0}
+llama-3.1-8b       Hallo {0}
+llama-3.2-3b       Hallo {0}
+llama-3.3-70b      Hallo {0}
+llama-4-scout      Hallo {0}
+mistral-small-3.1  Hallo {0}
+```
+
+**`message.count`**
+
+```
+en                 You have {0} of {1} messages
+m2m100             Sie haben {0} von {1} Nachrichten
+llama-3.1-8b       Sie haben {0} von {1} Nachrichten
+llama-3.2-3b       I habe {0} von {1} Nachrichten
+llama-3.3-70b      Sie haben {0} von {1} Nachrichten
+llama-4-scout      Sie haben {0} von {1} Nachrichten
+mistral-small-3.1  Sie haben {0} von {1} Nachrichten
+```
+
+**`message.repeat`**
+
+```
+en                 Hello {0}, we said hello {0} already
+m2m100             Hallo {0}, wir sagten Hallo {0} bereits
+llama-3.1-8b       Hallo {0}, wir sagten bereits Hallo {0}
+llama-3.2-3b       Hallo {0}, wir haben bereits {0} gesagt
+llama-3.3-70b      Hallo {0}, wir haben uns bereits verabschiedet {0} schon
+llama-4-scout      Hallo {0}, wir haben bereits Hallo {0} gesagt
+mistral-small-3.1  Hallo {0}, wir haben uns schon begr\u00fc\u00dft {0}
+```
+
+**`message.order`**
+
+```
+en                 {0} items shipped to {1} on {2}
+m2m100             {0} Artikel an {1} auf {2} versandt
+llama-3.1-8b       {0} Artikel wurden an {1} am {2} geschickt.
+llama-3.2-3b       {0} Artikel geliefert an {1} am {2}
+llama-3.3-70b      {0} Artikel an {1} am {2} geliefert
+llama-4-scout      {0} Artikel an {1} am {2} versendet
+mistral-small-3.1  {0} Artikel versendet an {1} am {2}
+```
+
+**`user.welcome`**
+
+```
+en                 Welcome back, ${name}
+m2m100             Willkommen zur\u00fcck, ${name}
+llama-3.1-8b       Willkommen zur\u00fcck, ${name}
+llama-3.2-3b       Willkommen zur\u00fcck, ${name}
+llama-3.3-70b      Willkommen zur\u00fcck, ${name}
+llama-4-scout      Willkommen zur\u00fcck, ${name}
+mistral-small-3.1  Willkommen zur\u00fcck, ${name}
+```
+
+**`user.profile`**
+
+```
+en                 Profile for ${user.name} in ${user.role}
+m2m100             Profil f\u00fcr ${user.name} in ${user.role}
+llama-3.1-8b       Profil f\u00fcr ${user.name} in ${user.role}
+llama-3.2-3b       Profile for ${user.name} in ${user.role}   <-- UNCHANGED
+llama-3.3-70b      Profil f\u00fcr ${user.name} in ${user.role}
+llama-4-scout      Profil f\u00fcr ${user.name} in ${user.role}
+mistral-small-3.1  Profil f\u00fcr ${user.name} in ${user.role}
+```
+
+**`stats.total`**
+
+```
+en                 Total: %s items
+m2m100             Gesamt\: %s Artikel
+llama-3.1-8b       Gesamt\: %s Artikel
+llama-3.2-3b       Gesamt\: %s Artikel
+llama-3.3-70b      Gesamt\: %s Artikel
+llama-4-scout      Insgesamt\: %s Artikel
+mistral-small-3.1  Gesamt\: %s Artikel
+```
+
+**`stats.indexed`**
+
+```
+en                 %1$s scored %2$d points
+m2m100             %1$s erzielt %2$d Punkte
+llama-3.1-8b       %1$s erzielte %2$d Punkte
+llama-3.2-3b       %1$s erzielte %2$d Punkte
+llama-3.3-70b      %1$s hat %2$d Punkte erzielt
+llama-4-scout      %1$s erzielte %2$d Punkte
+mistral-small-3.1  %1$s hat %2$d Punkte erzielt
+```
+
+**`alert.warning`**
+
+```
+en                 Warning, {0}!
+m2m100             Warnung {0}\!
+llama-3.1-8b       Warnung, {0}\!
+llama-3.2-3b       Vorsicht, {0}\!
+llama-3.3-70b      Warnung, {0}\!
+llama-4-scout      Warnung, {0}\!
+mistral-small-3.1  Warnung, {0}\!
+```
+
+**`alert.question`**
+
+```
+en                 Are you sure you want to delete {0}?
+m2m100             Sind Sie sicher, dass Sie {0} l\u00f6schen m\u00f6chten?
+llama-3.1-8b       Sind Sie sicher, dass Sie {0} l\u00f6schen m\u00f6chten?
+llama-3.2-3b       Are you sure you want to delete {0}?   <-- UNCHANGED
+llama-3.3-70b      Sind Sie sicher, dass Sie {0} l\u00f6schen m\u00f6chten?
+llama-4-scout      Sind Sie sicher, dass Sie {0} l\u00f6schen m\u00f6chten?
+mistral-small-3.1  Bist du sicher, dass du {0} l\u00f6schen m\u00f6chtest?
+```
+
+**`alert.parens`**
+
+```
+en                 Order ({0}) has shipped
+m2m100             Bestellung ({0}) wurde versandt
+llama-3.1-8b       Bestellung ({0}) wurde verschickt
+llama-3.2-3b       Bestellung ({0}) hat verschickt
+llama-3.3-70b      Bestellung ({0}) wurde versandt
+llama-4-scout      Bestellung ({0}) ist versendet worden
+mistral-small-3.1  Bestellung ({0}) wurde versendet
+```
+
+**`help.multiline`**
+
+```
+en                 First line\nSecond line
+m2m100             Erste Linie\nZZ Zweite Linie
+llama-3.1-8b       Erster Zeile\nZweite Zeile
+llama-3.2-3b       Erster Zeile\nZweite Zeile
+llama-3.3-70b      Erste Zeile\nZweite Zeile
+llama-4-scout      Erste Zeile\nZweite Zeile
+mistral-small-3.1  Erste Zeile\nZweite Zeile
+```
+
+**`help.tabbed`**
+
+```
+en                 Column one\tColumn two
+m2m100             Spalte one\tSpalte zwei
+llama-3.1-8b       Spalte \tSpalte zwei
+llama-3.2-3b       Spalte eins\tSpalte zwei
+llama-3.3-70b      Spalte eins\tSpalte zwei
+llama-4-scout      Spalte eins\tSpalte zwei
+mistral-small-3.1  Spalte eins\tSpalte zwei
+```
+
+**`help.unicode`**
+
+```
+en                 Café près de l’hôtel
+m2m100             Caf\u00e9 in der N\u00e4he des Hotels
+llama-3.1-8b       Kaffee nahe dem Hotel
+llama-3.2-3b       Kaffee in der N\u00e4he des Hotels
+llama-3.3-70b      Caf\u00e9 in der N\u00e4he des Hotels
+llama-4-scout      Caf\u00e9 nahe dem Hotel
+mistral-small-3.1  Caf\u00e9 in der N\u00e4he des Hotels
+```
+
+**`terms.long`**
+
+```
+en                 By continuing you agree to the terms {0} and the privacy policy {1} effective today
+m2m100             Durch die Fortsetzung erkl\u00e4ren Sie sich mit den Bedingungen {0} und der Datenschutzerkl\u00e4rung {1} heute g\u00fcltig.
+llama-3.1-8b       Indem Sie fortfahren, stimmen Sie den Bedingungen {0} und der Datenschutzerkl\u00e4rung {1} ab, die heute anwenden.
+llama-3.2-3b       Indem du forderst die Fortsetzung, stimmst du den Nutzungsbedingungen {0} und der Datenschutzrichtlinie {1} ab, die ab dem heutigen Tag anwendbar sind.
+llama-3.3-70b      Indem Sie fortfahren, stimmen Sie den Bedingungen {0} und der Datenschutzrichtlinie {1} ab, die heute in Kraft treten
+llama-4-scout      Indem Sie fortfahren, stimmen Sie den Bedingungen {0} und der Datenschutzerkl\u00e4rung {1} mit Wirkung vom heutigen Tag zu
+mistral-small-3.1  Durch das Fortfahren stimmen Sie den Bedingungen {0} und der Datenschutzrichtlinie {1} ab heute zu
+```
+
+**`footer.copyright`**
+
+```
+en                 All rights reserved  # do not translate the year
+m2m100             Alle Rechte vorbehalten  # do not translate the year
+llama-3.1-8b       Alle Rechte vorbehalten  # do not translate the year
+llama-3.2-3b       Alle Rechte vorbehalten  # do not translate the year
+llama-3.3-70b      Alle Rechte vorbehalten  # do not translate the year
+llama-4-scout      Alle Rechte vorbehalten  # do not translate the year
+mistral-small-3.1  Alle Rechte vorbehalten  # do not translate the year
+```
+
+**`error.permission`**
+
+```
+en                 You do not have permission to perform this action. Contact your administrator if you believe this is a mistake.
+m2m100             Sie haben keine Berechtigung, diese Aktion durchzuf\u00fchren. Kontaktieren Sie Ihren Administrator, wenn Sie glauben, dass dies ein Fehler ist.
+llama-3.1-8b       Sie haben keine Berechtigung, diese Aktion durchzuf\u00fchren. Wenden Sie sich an Ihren Administrator, wenn Sie glauben, dass dies ein Fehler ist.
+llama-3.2-3b       Sie haben keinen Zugriff auf diese Aktion. Wenden Sie sich an Ihren Administrator, wenn Sie glauben, dass dies ein Fehler ist.
+llama-3.3-70b      Sie haben keine Berechtigung, um diese Aktion auszuf\u00fchren. Wenden Sie sich an Ihren Administrator, wenn Sie der Meinung sind, dass dies ein Fehler ist.
+llama-4-scout      Sie haben keine Berechtigung, diese Aktion auszuf\u00fchren. Wenden Sie sich an Ihren Administrator, wenn Sie glauben, dass dies ein Fehler ist.
+mistral-small-3.1  Sie haben keine Berechtigung, diese Aktion auszuf\u00fchren. Wenden Sie sich an Ihren Administrator, wenn Sie glauben, dass dies ein Fehler ist.
+```
+
+**`onboarding.step`**
+
+```
+en                 Choose a workspace name. You can change it later in settings.
+m2m100             W\u00e4hlen Sie einen Arbeitsplatznamen aus. Sie k\u00f6nnen ihn sp\u00e4ter in den Einstellungen \u00e4ndern.
+llama-3.1-8b       W\u00e4hle einen Arbeitsbereichsnamen. Du kannst ihn sp\u00e4ter in den Einstellungen \u00e4ndern.
+llama-3.2-3b       Arbeitsplatzname w\u00e4hlen. Sie k\u00f6nnen es sp\u00e4ter in Einstellungen \u00e4ndern.
+llama-3.3-70b      W\u00e4hlen Sie einen Arbeitsbereichsnamen. Sie k\u00f6nnen ihn sp\u00e4ter in den Einstellungen \u00e4ndern.
+llama-4-scout      W\u00e4hlen Sie einen Arbeitsbereichsnamen. Sie k\u00f6nnen ihn sp\u00e4ter in den Einstellungen \u00e4ndern.
+mistral-small-3.1  W\u00e4hlen Sie einen Arbeitsbereichsnamen. Sie k\u00f6nnen ihn sp\u00e4ter in den Einstellungen \u00e4ndern.
+```
+
+### ja
+
+**`app.name`**
+
+```
+en                 Task Manager
+m2m100             \u30bf\u30b9\u30af\u30de\u30cd\u30fc\u30b8\u30e3\u30fc
+llama-3.1-8b       \u30bf\u30b9\u30af\u30de\u30cd\u30fc\u30b8\u30e3
+llama-3.2-3b       \u30bf\u30b9\u30af\u30de\u30cd\u30fc\u30b8\u30e3\u30fc
+llama-3.3-70b      \u30bf\u30b9\u30af\u30de\u30cd\u30fc\u30b8\u30e3\u30fc
+llama-4-scout      \u30bf\u30b9\u30af \u30de\u30cd\u30fc\u30b8\u30e3\u30fc
+mistral-small-3.1  \u30bf\u30b9\u30af \u30de\u30cd\u30fc\u30b8\u30e3\u30fc
+```
+
+**`app.welcome`**
+
+```
+en                 Welcome to your dashboard
+m2m100             \u3088\u3046\u3053\u305d\u3042\u306a\u305f\u306e\u30c0\u30c3\u30b7\u30e5\u30dc\u30fc\u30c9\u3078
+llama-3.1-8b       \u30c0\u30c3\u30b7\u30e5\u30dc\u30fc\u30c9\u306b\u3088\u3046\u3053\u305d
+llama-3.2-3b       welcome to your dashboard
+llama-3.3-70b      \u30c0\u30c3\u30b7\u30e5\u30dc\u30fc\u30c9\u3078\u3088\u3046\u3053\u305d
+llama-4-scout      \u30c0\u30c3\u30b7\u30e5\u30dc\u30fc\u30c9\u3078\u3088\u3046\u3053\u305d
+mistral-small-3.1  \u3088\u3046\u3053\u305d\u3001\u30c0\u30c3\u30b7\u30e5\u30dc\u30fc\u30c9\u3078
+```
+
+**`app.description`**
+
+```
+en                 Manage your projects and collaborate with your team in one place
+m2m100             \u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u3092\u7ba1\u7406\u3057\u30011\u3064\u306e\u5834\u6240\u3067\u30c1\u30fc\u30e0\u3068\u5354\u529b
+llama-3.1-8b       \u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u3092\u7ba1\u7406\u3057\u3001\u30c1\u30fc\u30e0\u3068\u5354\u529b\u3059\u308b\u5834\u6240\u306b\u3042\u308a\u307e\u3059\u3002
+llama-3.2-3b       {0}\u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u3092\u7ba1\u7406\u3057\u3001\u30c1\u30fc\u30e0\u3068\u5354\u529b\u3059\u308b\u5834\u6240\u3067 {1}
+llama-3.3-70b      \u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u3092\u7ba1\u7406\u3057\u3001\u4e00\u304b\u6240\u3067\u30c1\u30fc\u30e0\u3068\u5171\u540c\u4f5c\u696d\u3092\u884c\u3046
+llama-4-scout      \u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u3092\u7ba1\u7406\u3057\u3001\u30c1\u30fc\u30e0\u3068\u9023\u643a\u3057\u3066\u4e00\u3064\u306e\u5834\u6240\u3067\u4f5c\u696d\u3057\u307e\u3057\u3087\u3046
+mistral-small-3.1  \u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u3092\u7ba1\u7406\u3057\u3001\u30c1\u30fc\u30e0\u3068\u4e00\u7dd2\u306b\u5354\u529b\u3057\u3066\u4f5c\u696d\u3092\u9032\u3081\u308b
+```
+
+**`button.ok`**
+
+```
+en                 OK
+m2m100             OK   <-- UNCHANGED
+llama-3.1-8b       \uff2f\uff2b
+llama-3.2-3b       OK   <-- UNCHANGED
+llama-3.3-70b      OK   <-- UNCHANGED
+llama-4-scout      OK   <-- UNCHANGED
+mistral-small-3.1  OK   <-- UNCHANGED
+```
+
+**`button.save`**
+
+```
+en                 Save
+m2m100             SAVE
+llama-3.1-8b       \u30bb\u30fc\u30d6
+llama-3.2-3b       Save   <-- UNCHANGED
+llama-3.3-70b      \u4fdd\u5b58
+llama-4-scout      \u4fdd\u5b58
+mistral-small-3.1  \u4fdd\u5b58
+```
+
+**`label.hi`**
+
+```
+en                 Hi {0}
+m2m100             \u3053\u3093\u306b\u3061\u306f {0}
+llama-3.1-8b       \u3053\u3093\u306b\u3061\u306f{0}
+llama-3.2-3b       \u3053\u3093\u306b\u3061\u306f {0}
+llama-3.3-70b      \u3053\u3093\u306b\u3061\u306f {0}
+llama-4-scout      \u3053\u3093\u306b\u3061\u306f {0}
+mistral-small-3.1  \u3053\u3093\u306b\u3061\u306f {0}
+```
+
+**`label.bye`**
+
+```
+en                 Bye {0}
+m2m100             Bye {0}   <-- UNCHANGED
+llama-3.1-8b       \u30d0\u30a4\u30d0\u30a4 {0}
+llama-3.2-3b       \u3055\u3088\u3046\u306a\u3089 {0}
+llama-3.3-70b      \u3055\u3088\u3046\u306a\u3089 {0}
+llama-4-scout      \u3055\u3088\u3046\u306a\u3089 {0}
+mistral-small-3.1  \u3055\u3088\u3046\u306a\u3089 {0}
+```
+
+**`message.greeting`**
+
+```
+en                 Hello {0}
+m2m100             \u3053\u3093\u306b\u3061\u306f {0}
+llama-3.1-8b       \u3053\u3093\u306b\u3061\u306f {0}
+llama-3.2-3b       \u3053\u3093\u306b\u3061\u306f {0}
+llama-3.3-70b      \u3053\u3093\u306b\u3061\u306f {0}
+llama-4-scout      \u3053\u3093\u306b\u3061\u306f {0}
+mistral-small-3.1  \u3053\u3093\u306b\u3061\u306f {0}
+```
+
+**`message.count`**
+
+```
+en                 You have {0} of {1} messages
+m2m100             \u3042\u306a\u305f\u306f {1} \u30e1\u30c3\u30bb\u30fc\u30b8\u306e {0} \u3092\u6301\u3063\u3066\u3044\u307e\u3059
+llama-3.1-8b       {0}\u306e\u3046\u3061{1}\u306e\u30e1\u30c3\u30bb\u30fc\u30b8
+llama-3.2-3b       {0} of {1} messages
+llama-3.3-70b      {0} \u500b\u306e {1} \u30e1\u30c3\u30bb\u30fc\u30b8\u304c\u3042\u308a\u307e\u3059
+llama-4-scout      \u3042\u306a\u305f\u306f{0}\u4ef6\u306e{1}\u30e1\u30c3\u30bb\u30fc\u30b8\u3092\u6301\u3063\u3066\u3044\u307e\u3059
+mistral-small-3.1  \u3042\u306a\u305f\u306f {0} \u306e {1} \u30e1\u30c3\u30bb\u30fc\u30b8\u304c\u3042\u308a\u307e\u3059
+```
+
+**`message.repeat`**
+
+```
+en                 Hello {0}, we said hello {0} already
+m2m100             \u3053\u3093\u306b\u3061\u306f {0}, we said hello {0} already
+llama-3.1-8b       \u3053\u3093\u306b\u3061\u306f{0}\u3001\u3082\u3046{0}\u306b\u4f1a\u3063\u305f\u3053\u3068\u304c\u3042\u308b
+llama-3.2-3b       \u3053\u3093\u306b\u3061\u306f {0}\u3001\u79c1\u305f\u3061\u306f\u3059\u3067\u306b\u300c\u3053\u3093\u306b\u3061\u306f {0}\u300d\u3092\u8a00\u3063\u3066\u3044\u307e\u3057\u305f
+llama-3.3-70b      \u3053\u3093\u306b\u3061\u306f {0}\u3001\u79c1\u305f\u3061\u306f\u65e2\u306b {0} \u3053\u3093\u306b\u3061\u306f\u3068\u8a00\u3063\u305f
+llama-4-scout      \u3053\u3093\u306b\u3061\u306f {0}\u3001\u3082\u3046 {0} \u306b\u6328\u62f6\u3057\u307e\u3057\u305f\u3088\u306d
+mistral-small-3.1  \u3053\u3093\u306b\u3061\u306f {0}\u3001\u3082\u3046\u3053\u3093\u306b\u3061\u306f {0} \u3068\u8a00\u3044\u307e\u3057\u305f\u3002
+```
+
+**`message.order`**
+
+```
+en                 {0} items shipped to {1} on {2}
+m2m100             {0} items shipped to {1} on {2}   <-- UNCHANGED
+llama-3.1-8b       {0}\u54c1\u304c{1}\u306b{2}\u306b\u767a\u9001\u3055\u308c\u307e\u3057\u305f\u3002
+llama-3.2-3b       {0} \u500b\u306e\u54c1\u7269\u3092 {1} \u306b\u9001\u9054\u3057\u307e\u3057\u305f on {2}
+llama-3.3-70b      {0} \u500b\u306e\u5546\u54c1\u304c {1} \u306b {2} \u306b\u51fa\u8377\u3055\u308c\u307e\u3057\u305f
+llama-4-scout      {0} \u500b\u306e\u5546\u54c1\u304c {1} \u306b {2} \u306b\u767a\u9001\u3055\u308c\u307e\u3057\u305f
+mistral-small-3.1  {0}\u30a2\u30a4\u30c6\u30e0\u304c{1}\u306b{2}\u306b\u767a\u9001\u3055\u308c\u307e\u3057\u305f\u3002
+```
+
+**`user.welcome`**
+
+```
+en                 Welcome back, ${name}
+m2m100             \u3088\u3046\u3053\u305d\u3001${name}
+llama-3.1-8b       \u3088\u3046\u3053\u305d\u623b\u308a\u307e\u3057\u305f\u3001${name}
+llama-3.2-3b       \u304a\u4f1a\u3044\u3057\u3084\u3059\u3044\u3067\u3059\u3001${name}
+llama-3.3-70b      \u3088\u3046\u3053\u305d\u623b\u308a\u307e\u3057\u305f\u3001${name}
+llama-4-scout      \u304a\u623b\u308a\u306a\u3055\u3044\u3001${name}
+mistral-small-3.1  \u3088\u3046\u3053\u305d\u623b\u3063\u3066\u304d\u307e\u3057\u305f\u3001${name}
+```
+
+**`user.profile`**
+
+```
+en                 Profile for ${user.name} in ${user.role}
+m2m100             \u30d7\u30ed\u30d5\u30a3\u30fc\u30eb for ${user.name} in ${user.role}
+llama-3.1-8b       ${user.name}\u306e\u30d7\u30ed\u30d5\u30a1\u30a4\u30eb\uff08${user.role}\uff09
+llama-3.2-3b       \u30d7\u30ed\u30d5\u30a1\u30a4\u30eb\u306f${user.name}\u306b${user.role}\u3067\u3059
+llama-3.3-70b      ${user.name} \u306e\u30d7\u30ed\u30d5\u30a1\u30a4\u30eb in ${user.role}
+llama-4-scout      ${user.name}\u306e\u30d7\u30ed\u30d5\u30a1\u30a4\u30eb\uff08${user.role}\uff09
+mistral-small-3.1  ${user.name}\u306e${user.role}\u306e\u30d7\u30ed\u30d5\u30a3\u30fc\u30eb
+```
+
+**`stats.total`**
+
+```
+en                 Total: %s items
+m2m100             \u5408\u8a08\:%s\u9805\u76ee
+llama-3.1-8b       \u5408\u8a08\uff1a%s \u30a2\u30a4\u30c6\u30e0
+llama-3.2-3b       \u5408\u8a08\:%s\u9805\u76ee
+llama-3.3-70b      \u5408\u8a08\: %s \u4ef6
+llama-4-scout      \u5408\u8a08\: %s \u500b
+mistral-small-3.1  \u5408\u8a08\: %s \u4ef6
+```
+
+**`stats.indexed`**
+
+```
+en                 %1$s scored %2$d points
+m2m100             %1$s \u5f97\u70b9 %2$d \u30dd\u30a4\u30f3\u30c8
+llama-3.1-8b       %1$s\u306f%2$d\u70b9\u3092\u7372\u5f97\u3057\u307e\u3057\u305f\u3002
+llama-3.2-3b       %1$s \u304c %2$d \u30dd\u30a4\u30f3\u30c8
+llama-3.3-70b      %1$s \u306f %2$d \u70b9\u3092\u7372\u5f97\u3057\u307e\u3057\u305f
+llama-4-scout      %1$s\u304c%2$d\u70b9\u3092\u7372\u5f97\u3057\u307e\u3057\u305f
+mistral-small-3.1  %1$s\u306f%2$d\u70b9\u3092\u7372\u5f97\u3057\u307e\u3057\u305f
+```
+
+**`alert.warning`**
+
+```
+en                 Warning, {0}!
+m2m100             \u8b66\u544a {0}\!
+llama-3.1-8b       \u6ce8\u610f\u3001{0}\uff01
+llama-3.2-3b       \u6ce8\u610f\u3001{0}\u3067\u3059\u3002
+llama-3.3-70b      \u8b66\u544a\u3001{0}\uff01
+llama-4-scout      \u8b66\u544a\u3001{0}\uff01
+mistral-small-3.1  \u8b66\u544a\u3001{0}\uff01
+```
+
+**`alert.question`**
+
+```
+en                 Are you sure you want to delete {0}?
+m2m100             {0} \u3092\u524a\u9664\u3057\u305f\u3044\u3068\u601d\u3044\u307e\u3059\u304b?
+llama-3.1-8b       {0} \u306f\u524a\u9664\u3057\u307e\u3059\u304b\uff1f
+llama-3.2-3b       {0}
+llama-3.3-70b      {0}\u3092\u524a\u9664\u3057\u3066\u3088\u3044\u3067\u3059\u304b\uff1f
+llama-4-scout      \u672c\u5f53\u306b{0}\u3092\u524a\u9664\u3057\u307e\u3059\u304b\uff1f
+mistral-small-3.1  {0}\u3092\u524a\u9664\u3057\u3066\u3082\u3088\u308d\u3057\u3044\u3067\u3059\u304b\uff1f
+```
+
+**`alert.parens`**
+
+```
+en                 Order ({0}) has shipped
+m2m100             \u6ce8\u6587({0})\u304c\u767a\u9001\u3055\u308c\u307e\u3057\u305f\u3002
+llama-3.1-8b       \u6ce8\u6587\uff08{0})\u306f\u767a\u9001\u3055\u308c\u307e\u3057\u305f
+llama-3.2-3b       Order ({0})\u306f\u767a\u9001\u6e08\u307f\u3067\u3059
+llama-3.3-70b      \u6ce8\u6587 ({0}) \u306f\u51fa\u8377\u3055\u308c\u307e\u3057\u305f
+llama-4-scout      \u6ce8\u6587\uff08{0}\uff09\u304c\u51fa\u8377\u3055\u308c\u307e\u3057\u305f
+mistral-small-3.1  \u6ce8\u6587 ({0}) \u306f\u51fa\u8377\u3055\u308c\u307e\u3057\u305f
+```
+
+**`help.multiline`**
+
+```
+en                 First line\nSecond line
+m2m100             \u7b2c1\u7dda\n\u7b2c2\u7dda
+llama-3.1-8b       First line\n\n\nSecond line
+llama-3.2-3b       Hajimari \nNijuu sen
+llama-3.3-70b      \u5148\u884c\n\u6b21\u884c
+llama-4-scout      \u6700\u521d\u306e\u884c\n\uff12\u884c\u76ee
+mistral-small-3.1  \u6700\u521d\u306e\u884c\n\u4e8c\u884c\u76ee
+```
+
+**`help.tabbed`**
+
+```
+en                 Column one\tColumn two
+m2m100             \u30b3\u30e9\u30e0 one\t\u30b3\u30e9\u30e0 two
+llama-3.1-8b       \u4e00\u5217\t\u4e8c\u5217
+llama-3.2-3b       \u30ab\u30e9\u30e01\t\u30ab\u30e9\u30e02
+llama-3.3-70b      \u5217\u4e00\t\u5217\u4e8c
+llama-4-scout      \u52171\t\u52172
+mistral-small-3.1  \u52171\t\u52172
+```
+
+**`help.unicode`**
+
+```
+en                 Café près de l’hôtel
+m2m100             \u30db\u30c6\u30eb\u306e\u8fd1\u304f\u306e\u30ab\u30d5\u30a7
+llama-3.1-8b       \u30ab\u30d5\u30a7\u30fc\u3000\u30db\u30c6\u30eb\u306e\u8fd1\u304f
+llama-3.2-3b       \u30ab\u30d5\u30a7\u8fd1\u304f\u30db\u30c6\u30eb
+llama-3.3-70b      \u30db\u30c6\u30eb\u306e\u8fd1\u304f\u306b\u30ab\u30d5\u30a7
+llama-4-scout      \u30db\u30c6\u30eb\u8fd1\u304f\u306e\u30ab\u30d5\u30a7
+mistral-small-3.1  \u30db\u30c6\u30eb\u306e\u8fd1\u304f\u306e\u30ab\u30d5\u30a7
+```
+
+**`terms.long`**
+
+```
+en                 By continuing you agree to the terms {0} and the privacy policy {1} effective today
+m2m100             \u7d99\u7d9a\u3059\u308b\u3053\u3068\u306b\u3088\u308a\u3001\u3042\u306a\u305f\u306f\u672c\u65e5\u6709\u52b9\u306a\u300c{0} \u300d\u3068\u300c{1} \u300d\u306e\u30d7\u30e9\u30a4\u30d0\u30b7\u30fc\u30dd\u30ea\u30b7\u30fc\u306b\u540c\u610f\u3057\u307e\u3059\u3002
+llama-3.1-8b       {0} {1} \u4eca\u65e5\u304b\u3089\u6709\u52b9\u306a\u30d7\u30e9\u30a4\u30d0\u30b7\u30fc\u30dd\u30ea\u30b7\u30fc
+llama-3.2-3b       By jiritsu o tsukau toki ni, o genzai ni teiketsu shite imasu {0} to, mimi to iru kiseki {1} e no k\u014deki teiketsu shite imasu
+llama-3.3-70b      \u7d99\u7d9a\u3059\u308b\u3053\u3068\u3067\u3001{0} \u304a\u3088\u3073\u3001{1} \u4eca\u65e5\u3088\u308a\u52b9\u529b\u3092\u767a\u3059\u308b\u30d7\u30e9\u30a4\u30d0\u30b7\u30fc\u30dd\u30ea\u30b7\u30fc\u306b\u540c\u610f\u3059\u308b\u3053\u3068\u306b\u306a\u308a\u307e\u3059
+llama-4-scout      \u7d9a\u884c\u3059\u308b\u3068\u3001\u3042\u306a\u305f\u306f\u898f\u7d04 {0} \u304a\u3088\u3073\u30d7\u30e9\u30a4\u30d0\u30b7\u30fc\u30dd\u30ea\u30b7\u30fc {1} \u306b\u540c\u610f\u3057\u305f\u3053\u3068\u306b\u306a\u308a\u307e\u3059\uff08\u672c\u65e5\u3088\u308a\u6709\u52b9\uff09
+mistral-small-3.1  \u7d9a\u884c\u3059\u308b\u3053\u3068\u3067\u3001\u5229\u7528\u898f\u7d04 {0} \u304a\u3088\u3073\u30d7\u30e9\u30a4\u30d0\u30b7\u30fc\u30dd\u30ea\u30b7\u30fc {1} \u4eca\u65e5\u6709\u52b9\u3068\u306a\u308b\u3053\u3068\u306b\u540c\u610f\u3059\u308b
+```
+
+**`footer.copyright`**
+
+```
+en                 All rights reserved  # do not translate the year
+m2m100             All Rights Reserved \u3059\u3079\u3066\u306e\u6a29\u5229  # do not translate the year
+llama-3.1-8b       \u5168\u6a29\u4fdd\u6709  # do not translate the year
+llama-3.2-3b       All rights reserved  # do not translate the year   <-- UNCHANGED
+llama-3.3-70b      \u8457\u4f5c\u6a29\u6240\u6709  # do not translate the year
+llama-4-scout      \u3059\u3079\u3066\u306e\u6a29\u5229\u3092\u4fdd\u6709  # do not translate the year
+mistral-small-3.1  \u8457\u4f5c\u6a29\u6240\u6709  # do not translate the year
+```
+
+**`error.permission`**
+
+```
+en                 You do not have permission to perform this action. Contact your administrator if you believe this is a mistake.
+m2m100             \u3042\u306a\u305f\u306f\u3053\u306e\u30a2\u30af\u30b7\u30e7\u30f3\u3092\u5b9f\u884c\u3059\u308b\u6a29\u9650\u304c\u3042\u308a\u307e\u305b\u3093. \u3042\u306a\u305f\u304c\u3053\u306e\u30a8\u30e9\u30fc\u3060\u3068\u4fe1\u3058\u308b\u5834\u5408\u306f\u3001\u7ba1\u7406\u8005\u306b\u9023\u7d61\u3057\u3066\u304f\u3060\u3055\u3044\u3002
+llama-3.1-8b       \u3042\u306a\u305f\u306f\u3053\u306e\u30a2\u30af\u30b7\u30e7\u30f3\u3092\u5b9f\u884c\u3059\u308b\u6a29\u9650\u304c\u3042\u308a\u307e\u305b\u3093\u3002\u7ba1\u7406\u8005\u306b\u9023\u7d61\u3057\u3066\u304f\u3060\u3055\u3044\u3002
+llama-3.2-3b       You do not have permission to perform this action. Contact your administrator if you believe this is a mistake.   <-- UNCHANGED
+llama-3.3-70b      \u3053\u306e\u64cd\u4f5c\u3092\u5b9f\u884c\u3059\u308b\u6a29\u9650\u304c\u3042\u308a\u307e\u305b\u3093\u3002\u9593\u9055\u3044\u3067\u3042\u308b\u3068\u601d\u308f\u308c\u308b\u5834\u5408\u306f\u3001\u7ba1\u7406\u8005\u306b\u9023\u7d61\u3057\u3066\u304f\u3060\u3055\u3044\u3002
+llama-4-scout      \u3053\u306e\u64cd\u4f5c\u3092\u884c\u3046\u6a29\u9650\u304c\u3042\u308a\u307e\u305b\u3093\u3002\u8aa4\u308a\u3067\u3042\u308b\u3068\u601d\u308f\u308c\u308b\u5834\u5408\u306f\u3001\u7ba1\u7406\u8005\u306b\u9023\u7d61\u3057\u3066\u304f\u3060\u3055\u3044\u3002
+mistral-small-3.1  \u3053\u306e\u64cd\u4f5c\u3092\u5b9f\u884c\u3059\u308b\u6a29\u9650\u304c\u3042\u308a\u307e\u305b\u3093\u3002\u3053\u306e\u64cd\u4f5c\u304c\u8aa4\u308a\u3067\u3042\u308b\u3068\u8003\u3048\u308b\u5834\u5408\u306f\u3001\u7ba1\u7406\u8005\u306b\u9023\u7d61\u3057\u3066\u304f\u3060\u3055\u3044\u3002
+```
+
+**`onboarding.step`**
+
+```
+en                 Choose a workspace name. You can change it later in settings.
+m2m100             \u30ef\u30fc\u30af\u30b9\u30da\u30fc\u30b9\u540d\u3092\u9078\u629e\u3057\u307e\u3059. \u5f8c\u3067\u8a2d\u5b9a\u3067\u5909\u66f4\u3067\u304d\u307e\u3059\u3002
+llama-3.1-8b       \u4f5c\u696d\u30b9\u30da\u30fc\u30b9\u540d\u3092\u9078\u629e\u3057\u307e\u3059\u3002\u5f8c\u3067\u8a2d\u5b9a\u3067\u5909\u66f4\u3067\u304d\u307e\u3059\u3002
+llama-3.2-3b       Choose a workspace name. You can change it later in settings.   <-- UNCHANGED
+llama-3.3-70b      \u30ef\u30fc\u30af\u30b9\u30da\u30fc\u30b9\u540d\u3092\u9078\u629e\u3057\u3066\u304f\u3060\u3055\u3044\u3002\u5f8c\u3067\u8a2d\u5b9a\u304b\u3089\u5909\u66f4\u3067\u304d\u307e\u3059\u3002
+llama-4-scout      \u30ef\u30fc\u30af\u30b9\u30da\u30fc\u30b9\u540d\u3092\u9078\u629e\u3057\u3066\u304f\u3060\u3055\u3044\u3002\u5f8c\u3067\u8a2d\u5b9a\u3067\u5909\u66f4\u3067\u304d\u307e\u3059\u3002
+mistral-small-3.1  \u30ef\u30fc\u30af\u30b9\u30da\u30fc\u30b9\u306e\u540d\u524d\u3092\u9078\u629e\u3057\u3066\u304f\u3060\u3055\u3044\u3002\u8a2d\u5b9a\u3067\u5f8c\u304b\u3089\u5909\u66f4\u3067\u304d\u307e\u3059\u3002
+```

--- a/docs/model-comparison/low-resource-2026-07-27.md
+++ b/docs/model-comparison/low-resource-2026-07-27.md
@@ -1,0 +1,1395 @@
+# Model comparison: m2m100 vs llama-3.1-8b vs llama-4-scout
+
+Fixture: `comparison.properties` · Endpoint: `https://translatemessages-staging.justblackmagic.workers.dev/`
+
+## Summary
+
+Lower is better for every column except "translated".
+
+| Language | Model | Translated | Unchanged | Placeholders lost | Reported failures | Missing keys | Latency |
+|---|---|---|---|---|---|---|---|
+| ff | m2m100 | 9/25 | 16 | 0 | 13 | 0 | 2728ms |
+| ff | llama-3.1-8b | 20/25 | 5 | 0 | 1 | 0 | 2173ms |
+| ff | llama-4-scout | 25/25 | 0 | 0 | 0 | 0 | 1913ms |
+| ilo | m2m100 | 19/25 | 6 | 0 | 6 | 0 | 23287ms |
+| ilo | llama-3.1-8b | 25/25 | 0 | 0 | 0 | 0 | 47893ms |
+| ilo | llama-4-scout | 25/25 | 0 | 0 | 0 | 0 | 1208ms |
+| ns | m2m100 | 14/25 | 11 | 0 | 8 | 0 | 4192ms |
+| ns | llama-3.1-8b | 17/25 | 8 | 0 | 2 | 0 | 2332ms |
+| ns | llama-4-scout | 20/25 | 5 | 0 | 0 | 0 | 705ms |
+| wo | m2m100 | 14/25 | 11 | 0 | 8 | 0 | 7073ms |
+| wo | llama-3.1-8b | 22/25 | 3 | 0 | 3 | 0 | 3177ms |
+| wo | llama-4-scout | 24/25 | 1 | 0 | 1 | 0 | 1507ms |
+| ast | m2m100 | 24/25 | 1 | 0 | 1 | 0 | 10612ms |
+| ast | llama-3.1-8b | 24/25 | 1 | 0 | 1 | 0 | 2325ms |
+| ast | llama-4-scout | 25/25 | 0 | 0 | 0 | 0 | 1168ms |
+| am | m2m100 | 21/25 | 4 | 0 | 3 | 0 | 3307ms |
+| am | llama-3.1-8b | 22/25 | 3 | 0 | 3 | 0 | 6579ms |
+| am | llama-4-scout | 25/25 | 0 | 0 | 0 | 0 | 1452ms |
+
+## Side by side
+
+Read this part. The table above cannot tell you whether a translation is good,
+only whether it is structurally intact.
+
+### ff
+
+**`app.name`**
+
+```
+en             Task Manager
+m2m100         Teema
+llama-3.1-8b   Task Manager   <-- UNCHANGED
+llama-4-scout  Gestionnaire de t\u00e2ches
+```
+
+**`app.welcome`**
+
+```
+en             Welcome to your dashboard
+m2m100         Mo Di Mi Do Fr Sa So
+llama-3.1-8b   Bunnaa ka dashboard
+llama-4-scout  Welcoming ngal laawol \u0257uniyaarum {0}
+```
+
+**`app.description`**
+
+```
+en             Manage your projects and collaborate with your team in one place
+m2m100         Mo Di Mi Do Fr Sa So
+llama-3.1-8b   Gastreer yor projectiin hawtu kalaajo yuun, teamiin kalaajo yuun.
+llama-4-scout  Dii\u0263e nokku \u0253aleeji mum \u0253e ngam wata \u0253e e team ma \u0253e e gihndeeji e wonee
+```
+
+**`button.ok`**
+
+```
+en             OK
+m2m100         Kombi
+llama-3.1-8b   OK   <-- UNCHANGED
+llama-4-scout  Dikko
+```
+
+**`button.save`**
+
+```
+en             Save
+m2m100         Tigi
+llama-3.1-8b   Saar
+llama-4-scout  \u018aa\u0253\u0253a
+```
+
+**`label.hi`**
+
+```
+en             Hi {0}
+m2m100         Hi {0}   <-- UNCHANGED
+llama-3.1-8b   Xai {0}
+llama-4-scout  Bonjour {0}
+```
+
+**`label.bye`**
+
+```
+en             Bye {0}
+m2m100         Bye {0}   <-- UNCHANGED
+llama-3.1-8b   Tubabili {0}
+llama-4-scout  Baay {0}
+```
+
+**`message.greeting`**
+
+```
+en             Hello {0}
+m2m100         Hello {0}   <-- UNCHANGED
+llama-3.1-8b   Salaam {0}
+llama-4-scout  Bonjour {0}
+```
+
+**`message.count`**
+
+```
+en             You have {0} of {1} messages
+m2m100         You have {0} of {1} messages   <-- UNCHANGED
+llama-3.1-8b   Afrikii {0} j\u00ebfandikoo {1} bokk.
+llama-4-scout  Naa {0} des {1} mesaa\u01b3i
+```
+
+**`message.repeat`**
+
+```
+en             Hello {0}, we said hello {0} already
+m2m100         Hello {0}, we said hello {0} already   <-- UNCHANGED
+llama-3.1-8b   Salaam {0}, amal a ka faa {0}
+llama-4-scout  Bonjour {0}, nous avons d\u00e9j\u00e0 dit bonjour {0}
+```
+
+**`message.order`**
+
+```
+en             {0} items shipped to {1} on {2}
+m2m100         {0} items shipped to {1} on {2}   <-- UNCHANGED
+llama-3.1-8b   {0} itemsu xukkooni {1} le {2}
+llama-4-scout  {0} articles exp\u00e9di\u00e9s \u00e0 {1} le {2}
+```
+
+**`user.welcome`**
+
+```
+en             Welcome back, ${name}
+m2m100         Welcome back, ${name}   <-- UNCHANGED
+llama-3.1-8b   Buumi bukka, ${name}
+llama-4-scout  Welkam de, ${name}
+```
+
+**`user.profile`**
+
+```
+en             Profile for ${user.name} in ${user.role}
+m2m100         Profile for ${user.name} in ${user.role}   <-- UNCHANGED
+llama-3.1-8b   Fariin ${user.name} ayaan ${user.role}
+llama-4-scout  Profilu p\u00ebr ${user.name} n\u00eb ${user.role}
+```
+
+**`stats.total`**
+
+```
+en             Total: %s items
+m2m100         Total: %s items   <-- UNCHANGED
+llama-3.1-8b   Total\: %s items
+llama-4-scout  Totali\: %s tekkol
+```
+
+**`stats.indexed`**
+
+```
+en             %1$s scored %2$d points
+m2m100         %1$s scored %2$d points   <-- UNCHANGED
+llama-3.1-8b   %1$s aadaa %2$d bari
+llama-4-scout  %1$s njii %2$d punti
+```
+
+**`alert.warning`**
+
+```
+en             Warning, {0}!
+m2m100         Warning, {0}!   <-- UNCHANGED
+llama-3.1-8b   Warning, {0}!   <-- UNCHANGED
+llama-4-scout  Avertissement, {0} \!
+```
+
+**`alert.question`**
+
+```
+en             Are you sure you want to delete {0}?
+m2m100         Are you sure you want to delete {0}?   <-- UNCHANGED
+llama-3.1-8b   Sigi a mar a xaritaa {0}?
+llama-4-scout  Nee\u0257aama, \u00f1in gi naanaka delete {0}?
+```
+
+**`alert.parens`**
+
+```
+en             Order ({0}) has shipped
+m2m100         Order ({0}) has shipped   <-- UNCHANGED
+llama-3.1-8b   Order ({0}) aadaa yi aadaa
+llama-4-scout  Kiraa ({0}) de\u01b4ii\u0257e
+```
+
+**`help.multiline`**
+
+```
+en             First line\nSecond line
+m2m100         First line\nSecond line   <-- UNCHANGED
+llama-3.1-8b   First line\nSecond line   <-- UNCHANGED
+llama-4-scout  Premi\u00e8re ligne\nDeuxi\u00e8me ligne
+```
+
+**`help.tabbed`**
+
+```
+en             Column one\tColumn two
+m2m100         Column one\tColumn two   <-- UNCHANGED
+llama-3.1-8b   Column one\tColumn two   <-- UNCHANGED
+llama-4-scout  Sarakayel\tSarakayel mi\u0257ii
+```
+
+**`help.unicode`**
+
+```
+en             Café près de l’hôtel
+m2m100         Caf\u00e9 pr\u00e8s de l'h\u00f4tel
+llama-3.1-8b   Caf\u00e9 lagoni de hoteli
+llama-4-scout  Caf\u00e9 njool hotel
+```
+
+**`terms.long`**
+
+```
+en             By continuing you agree to the terms {0} and the privacy policy {1} effective today
+m2m100         By continuing you agree to the terms {0} and the privacy policy {1} effective today   <-- UNCHANGED
+llama-3.1-8b   By continuing you agree to the terms {0} na politika ya kujitolea kwa uhuru {1} inayofaa leo
+llama-4-scout  En continuant, vous acceptez les conditions {0} et la politique de confidentialit\u00e9 {1} effective aujourd'hui
+```
+
+**`footer.copyright`**
+
+```
+en             All rights reserved  # do not translate the year
+m2m100         Mo, Di, Mi, Do  # do not translate the year
+llama-3.1-8b   Todii xukkoon  # do not translate the year
+llama-4-scout  \u0181i\u0257e \u0257in hamma \n\n(Or, more formally, in a more suitable tone for "All rights reserved")\: \n\n\u0181i\u0257e \u0257in hamma ne \n\nHowever, considering standard translation practices for such phrases and ensuring it sounds natural in the target language\:\n\nHakkuuji \u0253uri \n\nis a more suitable and formal way to express "All rights reserved" in the language with ISO code "ff".  # do not translate the year
+```
+
+**`error.permission`**
+
+```
+en             You do not have permission to perform this action. Contact your administrator if you believe this is a mistake.
+m2m100         Mo Di Mi Do Fr Sa So
+llama-3.1-8b   Aa ka j\u00e0ngaaru waa xukkalee. Ka xukkalee waa xukkalee.
+llama-4-scout  Ndii\u0257e ngam yewtere \u0257in, hana yii\u0253e. \u0181awoore e maako diga administrator maa, tawde \u0257um ko \u0253alee.
+```
+
+**`onboarding.step`**
+
+```
+en             Choose a workspace name. You can change it later in settings.
+m2m100         Mo Di Mi Do Fr Sa So
+llama-3.1-8b   Nj\u00eb punonje e gjeode
+llama-4-scout  S\u00e9lectionnez un nom d'espace de travail. Vous pouvez le modifier ult\u00e9rieurement dans les param\u00e8tres.
+```
+
+### ilo
+
+**`app.name`**
+
+```
+en             Task Manager
+m2m100         Impanna iti Task Manager
+llama-3.1-8b   Mangaralas
+llama-4-scout  Tag-urong ti Trabaho
+```
+
+**`app.welcome`**
+
+```
+en             Welcome to your dashboard
+m2m100         Imtuodenyo iti dashboard.
+llama-3.1-8b   Salamat sa inyong dashboard
+llama-4-scout  Iturong iti dashboard mo
+```
+
+**`app.description`**
+
+```
+en             Manage your projects and collaborate with your team in one place
+m2m100         Manipud iti projekto ken collaborate iti team iti maysa a lugar.
+llama-3.1-8b   Nagmamanangayon ti nagpapalabas ken nagkaykaykayam ti proyekto kadagiti tattao.
+llama-4-scout  Agannad ken iramanyo dagiti proyekto mo ken kolaborar kadagiti ka-team mo iti maysa a lugar
+```
+
+**`button.ok`**
+
+```
+en             OK
+m2m100         OK iti
+llama-3.1-8b   Oo sariaye.
+llama-4-scout  Dios ti agngina
+```
+
+**`button.save`**
+
+```
+en             Save
+m2m100         Kayatna ti
+llama-3.1-8b   Sakop
+llama-4-scout  Ireserva
+```
+
+**`label.hi`**
+
+```
+en             Hi {0}
+m2m100         Hi {0}   <-- UNCHANGED
+llama-3.1-8b   Salaam {0}
+llama-4-scout  Nabati {0}
+```
+
+**`label.bye`**
+
+```
+en             Bye {0}
+m2m100         Goodbye iti {0}
+llama-3.1-8b   Bayi {0}
+llama-4-scout  Agan {0}
+```
+
+**`message.greeting`**
+
+```
+en             Hello {0}
+m2m100         Hello iti {0}
+llama-3.1-8b   Salamu {0}
+llama-4-scout  Nabati {0}
+```
+
+**`message.count`**
+
+```
+en             You have {0} of {1} messages
+m2m100         You have {0} of {1} messages   <-- UNCHANGED
+llama-3.1-8b   Ka {0} na {1} mensahe
+llama-4-scout  Adda {0} iti {1} a mensahe
+```
+
+**`message.repeat`**
+
+```
+en             Hello {0}, we said hello {0} already
+m2m100         Hello {0}, kitaem ti hello {0} laeng.
+llama-3.1-8b   Naimbag a pag-abot {0}, naimbag a pag-abot {0} metta
+llama-4-scout  Nabati {0}, nagbalin nga nabati {0} kami met
+```
+
+**`message.order`**
+
+```
+en             {0} items shipped to {1} on {2}
+m2m100         {0} items shipped to {1} on {2}   <-- UNCHANGED
+llama-3.1-8b   {0} items na ituyawadawad ni {1} idi {2}
+llama-4-scout  {0} nga baranga nga naipatakda ken {1} idi {2}
+```
+
+**`user.welcome`**
+
+```
+en             Welcome back, ${name}
+m2m100         Welcome back iti ${name}
+llama-3.1-8b   Salamat sa pagbalik, ${name}
+llama-4-scout  Nangngeg ka manen, ${name}
+```
+
+**`user.profile`**
+
+```
+en             Profile for ${user.name} in ${user.role}
+m2m100         Profile para iti ${user.name} iti ${user.role}
+llama-3.1-8b   Profile para kina ${user.name} sa ${user.role}
+llama-4-scout  Proyil para ${user.name} iti ${user.role}
+```
+
+**`stats.total`**
+
+```
+en             Total: %s items
+m2m100         Agtawenak idi iti %s item.
+llama-3.1-8b   Total\: %s items
+llama-4-scout  Kumplet\: %s nga ayatay
+```
+
+**`stats.indexed`**
+
+```
+en             %1$s scored %2$d points
+m2m100         %1$s scored %2$d points   <-- UNCHANGED
+llama-3.1-8b   Naiyaway %1$s %2$d puntos.
+llama-4-scout  %1$s nagskor ti %2$d puntos
+```
+
+**`alert.warning`**
+
+```
+en             Warning, {0}!
+m2m100         Ad-adu payen iti {0}\!
+llama-3.1-8b   Nagtaudan, {0}\!
+llama-4-scout  Babala, {0}\!
+```
+
+**`alert.question`**
+
+```
+en             Are you sure you want to delete {0}?
+m2m100         Kasano a ti inaramid ti {0}?
+llama-3.1-8b   Nagustuan ka sa pagtawag sa {0}?
+llama-4-scout  Sigurado ka nga kayat mo nga i-delete {0}?
+```
+
+**`alert.parens`**
+
+```
+en             Order ({0}) has shipped
+m2m100         Ti Order ({0}) ket nailawlawag.
+llama-3.1-8b   Naiyari ({0})
+llama-4-scout  Nayawanan ti order ({0})
+```
+
+**`help.multiline`**
+
+```
+en             First line\nSecond line
+m2m100         First line\nSecond line   <-- UNCHANGED
+llama-3.1-8b   Unang linya\nIkalawa linya
+llama-4-scout  Inakdan nga linia\nMaikadua a linia
+```
+
+**`help.tabbed`**
+
+```
+en             Column one\tColumn two
+m2m100         Column one\tColumn two   <-- UNCHANGED
+llama-3.1-8b   Pundong one\tPundong two
+llama-4-scout  Kulom uno\tKulom dua
+```
+
+**`help.unicode`**
+
+```
+en             Café près de l’hôtel
+m2m100         Kafe iti hotel.
+llama-3.1-8b   Kafe ti mabalin iti hotel
+llama-4-scout  Kafe iti asideg ti otel
+```
+
+**`terms.long`**
+
+```
+en             By continuing you agree to the terms {0} and the privacy policy {1} effective today
+m2m100         Iti panagturay, dakayo ti dakayo kadagiti terma ti {0} ken ti privacy policy ti {1} a maipaay iti daytoy nga aldaw.
+llama-3.1-8b   Nagpapatalon ka pay ket ti terms {0} ken ti privacy policy {1} amin a nagtutuloy a nagbalin epektibo amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nagbalin amin a nagtutuloy a nag
+llama-4-scout  Diosag iti pagtuluy, sang-ayunan mo ti termino {0} ken ti patakaran ti pribasiya {1} nga ag-ikkat itan nga aldaw
+```
+
+**`footer.copyright`**
+
+```
+en             All rights reserved  # do not translate the year
+m2m100         Dinan kayat a kitaen dagiti dadduma.  # do not translate the year
+llama-3.1-8b   Sakop na lahi.  # do not translate the year
+llama-4-scout  Nakareserba amin nga karbengan  # do not translate the year
+```
+
+**`error.permission`**
+
+```
+en             You do not have permission to perform this action. Contact your administrator if you believe this is a mistake.
+m2m100         Ti maysa ket addaan iti maysa kadagiti dua a tao.Kontakto ti administrator iti maysa a tao.
+llama-3.1-8b   Wakarayon ninyo amin a pamiyebalewto. Kansan ninyo amin amin administrator ninyo.
+llama-4-scout  Nadayup nga awan ka permit ti agaramana iti ganagna. Palaglagan ti administrador mo no mamati ka nga isu daytoy ti maysa a sala.
+```
+
+**`onboarding.step`**
+
+```
+en             Choose a workspace name. You can change it later in settings.
+m2m100         Ngem saan a naaddaan ti nagan ti lugar a trabaho, saan a naaddaan iti Settings.
+llama-3.1-8b   Igbanewa nke gburugburu.
+llama-4-scout  Pilian ti nagan ti workspace. Sabali ken change dagiti setting.
+```
+
+### ns
+
+**`app.name`**
+
+```
+en             Task Manager
+m2m100         Moka Moka
+llama-3.1-8b   Gestor de Tareas
+llama-4-scout  Gestionnaire de t\u00e2ches
+```
+
+**`app.welcome`**
+
+```
+en             Welcome to your dashboard
+m2m100         Moka Moka Moka
+llama-3.1-8b   Selamat datang di dashboard Anda
+llama-4-scout  Velkommen til dit kontrolpanel
+```
+
+**`app.description`**
+
+```
+en             Manage your projects and collaborate with your team in one place
+m2m100         Le boima le boima le boima le boima le boima.
+llama-3.1-8b   G\u00e9rer vos projets et collaborer avec votre \u00e9quipe dans un seul endroit
+llama-4-scout  Verwaltung von Projekten und Zusammenarbeit mit Ihrem Team an einem Ort
+```
+
+**`button.ok`**
+
+```
+en             OK
+m2m100         Moka
+llama-3.1-8b   OK   <-- UNCHANGED
+llama-4-scout  OK   <-- UNCHANGED
+```
+
+**`button.save`**
+
+```
+en             Save
+m2m100         Moka
+llama-3.1-8b   Saqla'
+llama-4-scout  Guardar
+```
+
+**`label.hi`**
+
+```
+en             Hi {0}
+m2m100         Hi {0}   <-- UNCHANGED
+llama-3.1-8b   Hiya {0}
+llama-4-scout  Hallo {0}
+```
+
+**`label.bye`**
+
+```
+en             Bye {0}
+m2m100         Bye {0}   <-- UNCHANGED
+llama-3.1-8b   Bye {0}   <-- UNCHANGED
+llama-4-scout  Auf Wiedersehen {0}
+```
+
+**`message.greeting`**
+
+```
+en             Hello {0}
+m2m100         Hello {0}   <-- UNCHANGED
+llama-3.1-8b   Hello {0}   <-- UNCHANGED
+llama-4-scout  Hallo {0}
+```
+
+**`message.count`**
+
+```
+en             You have {0} of {1} messages
+m2m100         You have {0} of {1} messages   <-- UNCHANGED
+llama-3.1-8b   You have {0} of {1} berita
+llama-4-scout  You have {0} of {1} meldinger
+```
+
+**`message.repeat`**
+
+```
+en             Hello {0}, we said hello {0} already
+m2m100         Hello {0}, we said hello {0} already   <-- UNCHANGED
+llama-3.1-8b   Hello {0}, kami sudah mengucapkan selamat pagi {0}
+llama-4-scout  Hallo {0}, wir haben bereits Hallo {0} gesagt
+```
+
+**`message.order`**
+
+```
+en             {0} items shipped to {1} on {2}
+m2m100         {0} items shipped to {1} on {2}   <-- UNCHANGED
+llama-3.1-8b   {0} items shipped to {1} on {2}   <-- UNCHANGED
+llama-4-scout  {0} art\u00edculos enviados a {1} el {2}
+```
+
+**`user.welcome`**
+
+```
+en             Welcome back, ${name}
+m2m100         Welcome back, ${name}   <-- UNCHANGED
+llama-3.1-8b   Selamat datang kembali, ${name}
+llama-4-scout  Willkommen zur\u00fcck, ${name}
+```
+
+**`user.profile`**
+
+```
+en             Profile for ${user.name} in ${user.role}
+m2m100         Profile for ${user.name} in ${user.role}   <-- UNCHANGED
+llama-3.1-8b   Profil untuk ${user.name} di ${user.role}
+llama-4-scout  Profil f\u00fcr ${user.name} in ${user.role}
+```
+
+**`stats.total`**
+
+```
+en             Total: %s items
+m2m100         Total: %s items   <-- UNCHANGED
+llama-3.1-8b   Total\: %s items
+llama-4-scout  Gesamt\: %s Artikel
+```
+
+**`stats.indexed`**
+
+```
+en             %1$s scored %2$d points
+m2m100         %1$s Goba %2$d Points
+llama-3.1-8b   %1$s a skorirao %2$d poena
+llama-4-scout  %1$s erzielte %2$d Punkte
+```
+
+**`alert.warning`**
+
+```
+en             Warning, {0}!
+m2m100         Wago, {0}\!
+llama-3.1-8b   Peringatan, {0}\!
+llama-4-scout  Achtung, {0}\!
+```
+
+**`alert.question`**
+
+```
+en             Are you sure you want to delete {0}?
+m2m100         Wago o hwet\u0161wa {0}?
+llama-3.1-8b   Are you sure you want to delete {0}?   <-- UNCHANGED
+llama-4-scout  Are you sure you want to delete {0}? -> \nAre you sure you want to delete {0}
+```
+
+**`alert.parens`**
+
+```
+en             Order ({0}) has shipped
+m2m100         Order ({0}) le bo\u0161weu
+llama-3.1-8b   Order ({0}) telah dikirim
+llama-4-scout  Bestilling ({0}) er sendt
+```
+
+**`help.multiline`**
+
+```
+en             First line\nSecond line
+m2m100         First line\nSecond line   <-- UNCHANGED
+llama-3.1-8b   First line\nSecond line   <-- UNCHANGED
+llama-4-scout  First line\nSecond line   <-- UNCHANGED
+```
+
+**`help.tabbed`**
+
+```
+en             Column one\tColumn two
+m2m100         kolona 1\tkolona 2
+llama-3.1-8b   Column one\tColumn two   <-- UNCHANGED
+llama-4-scout  Column one\tColumn two   <-- UNCHANGED
+```
+
+**`help.unicode`**
+
+```
+en             Café près de l’hôtel
+m2m100         Moka Moka Moka Moka
+llama-3.1-8b   Caf\u00e9 pr\u00e8s de l'h\u00f4tel
+llama-4-scout  Caf\u00e9 near the hotel
+```
+
+**`terms.long`**
+
+```
+en             By continuing you agree to the terms {0} and the privacy policy {1} effective today
+m2m100         By continuing you agree to the terms {0} and the privacy policy {1} effective today   <-- UNCHANGED
+llama-3.1-8b   By continuing you agree to the terms {0} and the privacy policy {1} effective today   <-- UNCHANGED
+llama-4-scout  By continuing you agree to the terms {0} and the privacy policy {1} effective today   <-- UNCHANGED
+```
+
+**`footer.copyright`**
+
+```
+en             All rights reserved  # do not translate the year
+m2m100         Moka Moka  # do not translate the year
+llama-3.1-8b   Tous droits r\u00e9serv\u00e9s  # do not translate the year
+llama-4-scout  Alle Rechte vorbehalten  # do not translate the year
+```
+
+**`error.permission`**
+
+```
+en             You do not have permission to perform this action. Contact your administrator if you believe this is a mistake.
+m2m100         Maemo a nkgethilwe ke a nkgethilwe ke a nkgethilwe ke a nkgethilwe ke a nkgethilwe ke a nkgethilwe ke a nkgethilwe ke a nkgethilwe ke a nkgethilwe ke a nkgethilwe ke a nkgethilwe ke a nkgethilwe ke a nkgethilwe ke a nkgethilwe ke a nkgethilwe.
+llama-3.1-8b   You do not have permission to perform this action. Please contact your administrator if you believe this is an error.
+llama-4-scout  You do not have permission to perform this action. Contact your administrator if you believe this is a mistake.   <-- UNCHANGED
+```
+
+**`onboarding.step`**
+
+```
+en             Choose a workspace name. You can change it later in settings.
+m2m100         Tshepidi\u0161o ya t\u0161hirelet\u0161o ya t\u0161hirelet\u0161o ya t\u0161hirelet\u0161o ya t\u0161hirelet\u0161o ya t\u0161hirelet\u0161o.
+llama-3.1-8b   Wybierz nazw\u0119 przestrzeni roboczej. Mo\u017cesz zmieni\u0107 j\u0105 p\u00f3\u017aniej w ustawieniach.
+llama-4-scout  W\u00e4hlen Sie einen Arbeitsbereichsnamen. Sie k\u00f6nnen ihn sp\u00e4ter in den Einstellungen \u00e4ndern.
+```
+
+### wo
+
+**`app.name`**
+
+```
+en             Task Manager
+m2m100         TOPP
+llama-3.1-8b   G\u00e0ttinaayu w\u00e0llif
+llama-4-scout  Gestionnaire de t\u00e2ches
+```
+
+**`app.welcome`**
+
+```
+en             Welcome to your dashboard
+m2m100         Lees meer \u00bb
+llama-3.1-8b   Benvueni ngi \u00e0q ndoxe yi.
+llama-4-scout  Ndakaru ci dashboard yi
+```
+
+**`app.description`**
+
+```
+en             Manage your projects and collaborate with your team in one place
+m2m100         Lees meer \u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb
+llama-3.1-8b   Gawriw yu benn team yu ngir wiyaas ak gis team yu nj\u00ebkk.
+llama-4-scout  Gerir d\u00ebkk bu ci projet yi ak kollaborer ak ekip bu ci nj\u00ebkk
+```
+
+**`button.ok`**
+
+```
+en             OK
+m2m100         Beeg
+llama-3.1-8b   Akk\n\nWaxtu.
+llama-4-scout  Dakaru
+```
+
+**`button.save`**
+
+```
+en             Save
+m2m100         digg
+llama-3.1-8b   Saw\n\n(No change, as "Save" is a single word)
+llama-4-scout  Sauvegarder
+```
+
+**`label.hi`**
+
+```
+en             Hi {0}
+m2m100         Hi {0}   <-- UNCHANGED
+llama-3.1-8b   Jamono {0}
+llama-4-scout  Salaam {0}
+```
+
+**`label.bye`**
+
+```
+en             Bye {0}
+m2m100         Bye {0}   <-- UNCHANGED
+llama-3.1-8b   Bisumal {0}
+llama-4-scout  Ndak {0}
+```
+
+**`message.greeting`**
+
+```
+en             Hello {0}
+m2m100         Hello {0}   <-- UNCHANGED
+llama-3.1-8b   Hello {0}   <-- UNCHANGED
+llama-4-scout  J\u00ebndel {0}
+```
+
+**`message.count`**
+
+```
+en             You have {0} of {1} messages
+m2m100         {0} of {1} amul
+llama-3.1-8b   Ndoofu {0} of {1} bokk\n\nor\n\nNdoofu {0} of {1} bokkale
+llama-4-scout  Nguy {0} ci {1} mbay
+```
+
+**`message.repeat`**
+
+```
+en             Hello {0}, we said hello {0} already
+m2m100         Hello {0}, we said hello {0} ya
+llama-3.1-8b   Jamono {0}, am naa jamono {0} ame
+llama-4-scout  J\u00ebnd {0}, jenu j\u00ebnd {0} d\u00e9jj\u00e9
+```
+
+**`message.order`**
+
+```
+en             {0} items shipped to {1} on {2}
+m2m100         {0} items shipped to {1} on {2}   <-- UNCHANGED
+llama-3.1-8b   {0} jiitante yu {1} le {2}
+llama-4-scout  {0} articles exp\u00e9di\u00e9s \u00e0 {1} le {2}
+```
+
+**`user.welcome`**
+
+```
+en             Welcome back, ${name}
+m2m100         Welcome back, ${name}   <-- UNCHANGED
+llama-3.1-8b   A bonday ci, ${name}
+llama-4-scout  Ndakaru weer, ${name}
+```
+
+**`user.profile`**
+
+```
+en             Profile for ${user.name} in ${user.role}
+m2m100         Profile for ${user.name} in ${user.role}   <-- UNCHANGED
+llama-3.1-8b   Dakkuwaayu asukuru ${user.name} ak moom ajiit ${user.role}
+llama-4-scout  Profile for ${user.name} in ${user.role}   <-- UNCHANGED
+```
+
+**`stats.total`**
+
+```
+en             Total: %s items
+m2m100         Total\: %s items
+llama-3.1-8b   Total: %s items   <-- UNCHANGED
+llama-4-scout  Ndakaru\: %s yaw \n\n(Or, more naturally in Wolof\: J\u00ebm\: %s yi )
+```
+
+**`stats.indexed`**
+
+```
+en             %1$s scored %2$d points
+m2m100         %1$s gni %2$d points
+llama-3.1-8b   Jii ko xam-xam %1$s %2$d bataaxel.
+llama-4-scout  %1$s m\u00ebn %2$d punti
+```
+
+**`alert.warning`**
+
+```
+en             Warning, {0}!
+m2m100         Warning, {0}!   <-- UNCHANGED
+llama-3.1-8b   Waa waa {0}\!
+llama-4-scout  Yay, {0}\!
+```
+
+**`alert.question`**
+
+```
+en             Are you sure you want to delete {0}?
+m2m100         Are you sure you want to delete {0}?   <-- UNCHANGED
+llama-3.1-8b   Are you sure you want to delete {0}?   <-- UNCHANGED
+llama-4-scout  Ndak rek \u00f1u d\u00eblee {0}?
+```
+
+**`alert.parens`**
+
+```
+en             Order ({0}) has shipped
+m2m100         Beeg ({0})
+llama-3.1-8b   Jumtugale ({0}) a w\u00e0ccoo.
+llama-4-scout  Komanda ({0}) moo ngodem
+```
+
+**`help.multiline`**
+
+```
+en             First line\nSecond line
+m2m100         First line\nSecond line   <-- UNCHANGED
+llama-3.1-8b   Jattu\nLiggeey\n\nNote\: I assume "XQZ" is a placeholder and "0" is a number, so I left them as is.
+llama-4-scout  Premi\u00e8re ligne\nDeuxi\u00e8me ligne
+```
+
+**`help.tabbed`**
+
+```
+en             Column one\tColumn two
+m2m100         Column one\tColumn two   <-- UNCHANGED
+llama-3.1-8b   Column waa\tColumn biir\n\nNote\: I assume "biir" is the correct translation for "two" in Wolof. If not, please let me know.
+llama-4-scout  Kolon nj\u00eb\tKolon deux
+```
+
+**`help.unicode`**
+
+```
+en             Café près de l’hôtel
+m2m100         Cafe pr\u00e8s de l'h\u00f4tel
+llama-3.1-8b   Caf\u00e9 d\u00e9kat h\u00f4tel
+llama-4-scout  Caf\u00e9 buur si l\u00ebkkalub\u00eb
+```
+
+**`terms.long`**
+
+```
+en             By continuing you agree to the terms {0} and the privacy policy {1} effective today
+m2m100         By continuing you agree to the terms {0} and the privacy policy {1} effective today   <-- UNCHANGED
+llama-3.1-8b   Na defaral ngir aya, aya yor ngir tekk tekkal tekkal {0} ak tekk tekkal tekkal {1} ak yor ngir aya yor.
+llama-4-scout  Mou contunu\u00e9 ndakko lekk {0} ak luwaay bu yaxu {1} \u00f1u wuutu ci wonee
+```
+
+**`footer.copyright`**
+
+```
+en             All rights reserved  # do not translate the year
+m2m100         D E F  # do not translate the year
+llama-3.1-8b   Yimun ciyaafe.  # do not translate the year
+llama-4-scout  L\u00ebkk\u00ebr yi r\u00e9server  # do not translate the year
+```
+
+**`error.permission`**
+
+```
+en             You do not have permission to perform this action. Contact your administrator if you believe this is a mistake.
+m2m100         T\u00e9l\u00e9fone / T\u00e9l\u00e9fone / T\u00e9l\u00e9fone / T\u00e9l\u00e9fone / T\u00e9l\u00e9fone / T\u00e9l\u00e9fone / T\u00e9l\u00e9fone / T\u00e9l\u00e9fone
+llama-3.1-8b   Aar aadaam, aadaam a yor aadaam. Nguur a yor aadaam, aadaam a yor aadaam.
+llama-4-scout  Ndakaru ci ndulenee woonu ci action bi. Luumu administrator bi laawol ci ndakaru yi ngir t\u00e0ng naawoonu.
+```
+
+**`onboarding.step`**
+
+```
+en             Choose a workspace name. You can change it later in settings.
+m2m100         Lees meer \u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb\u00bb
+llama-3.1-8b   Nj\u00ebb workspace nii.
+llama-4-scout  S\u00e9lectionnez un nom d'espace de travail. Vous pouvez le modifier plus tard dans les param\u00e8tres.
+```
+
+### ast
+
+**`app.name`**
+
+```
+en             Task Manager
+m2m100         Xestor de Tareas
+llama-3.1-8b   Xegresu de tareas
+llama-4-scout  Xestor de Tarees
+```
+
+**`app.welcome`**
+
+```
+en             Welcome to your dashboard
+m2m100         Bienven\u00edu al Dashboard
+llama-3.1-8b   Bienven\u00edu al teu panel de control
+llama-4-scout  Bienven\u00edu al to panel de control
+```
+
+**`app.description`**
+
+```
+en             Manage your projects and collaborate with your team in one place
+m2m100         Xestionar los sos proyectos y collaborar col so equipu nun llugar
+llama-3.1-8b   Xunir y xestionar los sos proyeutos y collaborar con el so equipu nun llugar
+llama-4-scout  Alministra los tos proyeutos y collaborar col equipu nun solu sitiu
+```
+
+**`button.ok`**
+
+```
+en             OK
+m2m100         De xac\u00edu
+llama-3.1-8b   D'acord
+llama-4-scout  Bien
+```
+
+**`button.save`**
+
+```
+en             Save
+m2m100         S\u00e1bese
+llama-3.1-8b   G\u00fcarden
+llama-4-scout  Guardar
+```
+
+**`label.hi`**
+
+```
+en             Hi {0}
+m2m100         Gracies {0}
+llama-3.1-8b   Bai {0}
+llama-4-scout  Hola {0}
+```
+
+**`label.bye`**
+
+```
+en             Bye {0}
+m2m100         Bye {0}   <-- UNCHANGED
+llama-3.1-8b   Adi\u00f3s {0}
+llama-4-scout  Adi\u00f3s {0}
+```
+
+**`message.greeting`**
+
+```
+en             Hello {0}
+m2m100         Gracies {0}
+llama-3.1-8b   Buen d\u00eda {0}
+llama-4-scout  Hola {0}
+```
+
+**`message.count`**
+
+```
+en             You have {0} of {1} messages
+m2m100         Tienes {0} de {1} mensaxes
+llama-3.1-8b   Tienes {0} de {1} mensaxes
+llama-4-scout  Tienes {0} de {1} mensaxes
+```
+
+**`message.repeat`**
+
+```
+en             Hello {0}, we said hello {0} already
+m2m100         Hello {0}, y\u00e1 dixemos hello {0}
+llama-3.1-8b   Hola {0}, d\u00edmosos hola {0} ya
+llama-4-scout  Hola {0}, diximos hola {0} y\u00e1
+```
+
+**`message.order`**
+
+```
+en             {0} items shipped to {1} on {2}
+m2m100         {0} art\u00edculos embarcaos a {1} en {2}
+llama-3.1-8b   Art\u00edculos {0} env\u00edaos a {1} el {2}
+llama-4-scout  {0} unid\u00e1(es) unviada(s) a {1} el {2}
+```
+
+**`user.welcome`**
+
+```
+en             Welcome back, ${name}
+m2m100         Bienven\u00edu al regresu ${name}
+llama-3.1-8b   Bienven\u00edu de nuevu, ${name}
+llama-4-scout  Bienven\u00edu de vuelta, ${name}
+```
+
+**`user.profile`**
+
+```
+en             Profile for ${user.name} in ${user.role}
+m2m100         Profile pa ${user.name} en ${user.role}
+llama-3.1-8b   Perfil pa ${user.name} en ${user.role}
+llama-4-scout  Perfil de ${user.name} en ${user.role}
+```
+
+**`stats.total`**
+
+```
+en             Total: %s items
+m2m100         Total\: %s elementos
+llama-3.1-8b   Total\: %s elementos
+llama-4-scout  Total\: %s elementos
+```
+
+**`stats.indexed`**
+
+```
+en             %1$s scored %2$d points
+m2m100         %1$s anot\u00e1u %2$d puntos
+llama-3.1-8b   Anque %1$s anot\u00f3 %2$d puntos
+llama-4-scout  %1$s consigui\u00f3 %2$d puntos
+```
+
+**`alert.warning`**
+
+```
+en             Warning, {0}!
+m2m100         \u00a1Alvertencia {0}\!
+llama-3.1-8b   Atenci\u00f3n, {0}\!
+llama-4-scout  Advertencia, {0}\!
+```
+
+**`alert.question`**
+
+```
+en             Are you sure you want to delete {0}?
+m2m100         \u00bfTienes segurid\u00e1 de que quieres esaniciar {0}?
+llama-3.1-8b   \u00bfTienes seguru de que quieras borrar {0}?
+llama-4-scout  \u00bfEst\u00e1s seguro de que quies deshacer de {0}?
+```
+
+**`alert.parens`**
+
+```
+en             Order ({0}) has shipped
+m2m100         La orde ({0}) foi unviada
+llama-3.1-8b   Ordeya ({0}) tresport\u00f3se
+llama-4-scout  El pid\u00edu ({0}) sali\u00f3 en cam\u00edn
+```
+
+**`help.multiline`**
+
+```
+en             First line\nSecond line
+m2m100         Primera llinia\nSegunda llinia
+llama-3.1-8b   Llinia primeru\nSegunda llinia
+llama-4-scout  Primer ll\u00ednea\nSegunda llinia
+```
+
+**`help.tabbed`**
+
+```
+en             Column one\tColumn two
+m2m100         Columna unu\tColumna dos
+llama-3.1-8b   Column one\tColumn two   <-- UNCHANGED
+llama-4-scout  Columnu unu\tColumnu dos
+```
+
+**`help.unicode`**
+
+```
+en             Café près de l’hôtel
+m2m100         Caf\u00e9 cerca del hotel
+llama-3.1-8b   Caf\u00e9 cerca de l'hoteles
+llama-4-scout  Caf\u00e9 cerca del hotel
+```
+
+**`terms.long`**
+
+```
+en             By continuing you agree to the terms {0} and the privacy policy {1} effective today
+m2m100         Al siguir aceptando acepta los t\u00e9rminos {0} y la pol\u00edtica de privacid\u00e1 {1} efectiva g\u00fcei
+llama-3.1-8b   Acordies con que sigas los t\u00e9rminos {0} y la pol\u00edtica de privacid\u00e1 {1} efeutiva dende g\u00fcei
+llama-4-scout  De sigu\u00edo, aceptes los t\u00e9rminos {0} y la pol\u00edtica de privacida {1} efeutivos d' g\u00fcei
+```
+
+**`footer.copyright`**
+
+```
+en             All rights reserved  # do not translate the year
+m2m100         Todos los derechos reservados  # do not translate the year
+llama-3.1-8b   Tolos derechos reservaos  # do not translate the year
+llama-4-scout  Toes los derechos reservaos  # do not translate the year
+```
+
+**`error.permission`**
+
+```
+en             You do not have permission to perform this action. Contact your administrator if you believe this is a mistake.
+m2m100         Nun tien permisu pa realizar esta acci\u00f3n.Contacte col so administrador si cree que ye un erru.
+llama-3.1-8b   Nun tien decesu permisu pa facer esti acci\u00f3n. Contauta col to administrator si crees que ye un error.
+llama-4-scout  No tienes permisu pa realizar esta aici\u00f3n. Contauta col alministrador si crees que ye un error.
+```
+
+**`onboarding.step`**
+
+```
+en             Choose a workspace name. You can change it later in settings.
+m2m100         Escoyer un nome d'espaciu de trabayu. Puede camudalo m\u00e1s tarde nes configuraciones.
+llama-3.1-8b   Eliaxea un nome de trabayu. Puedes camudarlu m\u00e1s palantre nos rexistros de configuraci\u00f3n.
+llama-4-scout  Escueye un nome pa workspace. Podes camudarlu m\u00e1s tarde en axustes.
+```
+
+### am
+
+**`app.name`**
+
+```
+en             Task Manager
+m2m100         \u12e8\u1274\u12ad\u1296\u120e\u1302 \u12a0\u1235\u1270\u12f3\u12f0\u122d
+llama-3.1-8b   \u1263\u1208\u121b\u1295\u1308\u1275
+llama-4-scout  \u12e8\u1270\u130d\u1263\u122d \u12a0\u1235\u1270\u12f3\u12f3\u122a
+```
+
+**`app.welcome`**
+
+```
+en             Welcome to your dashboard
+m2m100         \u12e8\u12a5\u122d\u1235\u12ce Dashboard \u120b\u12ed \u12ed\u121d\u1228\u1321
+llama-3.1-8b   \u12a0\u121b\u12ab\u1295\u1271 \u1208\u129b\u12ed\u1295\u1308\u122d
+llama-4-scout  \u12f3\u123d\u1266\u122d\u12f1\u1295 \u1208\u1218\u1240\u120b\u1240\u120d \u12a5\u1295\u12b3\u1295 \u12f0\u1205\u1293 \u1218\u1321
+```
+
+**`app.description`**
+
+```
+en             Manage your projects and collaborate with your team in one place
+m2m100         \u12e8\u12a5\u122d\u1235\u12ce\u1295 \u1355\u122e\u1300\u12ad\u1276\u127d \u12a0\u1235\u1270\u12f3\u12f0\u122d \u12a5\u1293 \u12a0\u1295\u12f5 \u1266\u1273 \u12cd\u1235\u1325 \u12e8\u12a5\u122d\u1235\u12ce \u1261\u12f5\u1295 \u130b\u122d \u12ed\u1230\u122b\u120d
+llama-3.1-8b   \u12a0\u1235\u1270\u12f3\u121d\u1229 \u12a5\u1293 \u1263\u1208\u121b\u12ad\u1230\u120d \u12a5\u1293\u1275 \u12a0\u1295\u12f5 \u1266\u1273 \u120b\u12ed
+llama-4-scout  \u12a0\u1295\u12f5 \u1266\u1273 \u120b\u12ed \u12e8\u12a5\u122d\u1235\u12ce\u1295 \u1355\u122e\u1300\u12ad\u1276\u127d \u12eb\u1235\u1270\u12f3\u12f5\u1229 \u12a5\u1293 \u12a8\u1261\u12f5\u1295\u12ce \u130b\u122d \u12ed\u1270\u1263\u1260\u1229
+```
+
+**`button.ok`**
+
+```
+en             OK
+m2m100         \u12a0\u12ce
+llama-3.1-8b   \u12a0\u1295\u12f5\u12a9
+llama-4-scout  \u12a5\u123a
+```
+
+**`button.save`**
+
+```
+en             Save
+m2m100         \u12eb\u130d\u1299\u1295
+llama-3.1-8b   \u1270\u12a8\u1270\u1270
+llama-4-scout  \u12a0\u1235\u1240\u121d\u1325
+```
+
+**`label.hi`**
+
+```
+en             Hi {0}
+m2m100         \u12a5\u1263\u12ad\u12ce {0}
+llama-3.1-8b   \u1230\u120b\u121d {0}
+llama-4-scout  \u1230\u120b\u121d {0}
+```
+
+**`label.bye`**
+
+```
+en             Bye {0}
+m2m100         \u12a0\u130d\u1299\u1295 {0}
+llama-3.1-8b   \u12a0\u120d\u1245\u121d\u122b\u1208\u1201 {0}
+llama-4-scout  \u1230\u120b\u121d {0}
+```
+
+**`message.greeting`**
+
+```
+en             Hello {0}
+m2m100         \u12a5\u1263\u12ad\u12ce {0}
+llama-3.1-8b   \u12a0\u1235\u121b\u121b\u1208\u1201 {0}
+llama-4-scout  \u1230\u120b\u121d {0}
+```
+
+**`message.count`**
+
+```
+en             You have {0} of {1} messages
+m2m100         \u12a5\u122d\u1235\u12ce {0} \u12e8 {1} \u12a0\u1235\u1270\u12eb\u12e8\u1276\u127d \u12a0\u120b\u1278\u12cd
+llama-3.1-8b   \u12a0\u1295\u12f5 {0} \u12a0\u121b\u12ab\u12ac\u1295 {1}
+llama-4-scout  \u12a5\u122d\u1235\u12ce {0} \u12e8{1} \u1218\u120d\u12d5\u12ad\u1276\u127d \u12a0\u1209\u12ce\u1275
+```
+
+**`message.repeat`**
+
+```
+en             Hello {0}, we said hello {0} already
+m2m100         Hello {0}, we said hello {0} already   <-- UNCHANGED
+llama-3.1-8b   \u12a0\u1235\u1240\u12cd\u1230\u1295 {0} \u12a5\u1295\u12f0\u121a\u1208\u12cd \u12a0\u1235\u1240\u12cd\u1230\u1295 {0} \u12a0\u1208
+llama-4-scout  \u1230\u120b\u121d {0}, \ubc8c\uc368 {0} \u1230\u120b\u121d \u12a5\u1295\u12f5\u1295\u120b\u12ad \u1290\u1260\u122d
+```
+
+**`message.order`**
+
+```
+en             {0} items shipped to {1} on {2}
+m2m100         \u1260 {2} \u120b\u12ed \u1260 {1} \u12c8\u12f0 {0} \u1241\u1233\u1241\u1236\u127d \u1270\u1295\u1240\u1233\u1243\u123d
+llama-3.1-8b   \u12a0\u1308\u1295\u1263\u1275 {0} \u12a0\u1235\u1270\u12cb\u120d \u1260 {1} \u1260 {2}
+llama-4-scout  {0} \u12d5\u1243\u12ce\u127d \u12c8\u12f0 {1} \u12e8\u1270\u120b\u12a9\u1260\u1275 \u1240\u1295 {2} \u1290\u12cd\u1362
+```
+
+**`user.welcome`**
+
+```
+en             Welcome back, ${name}
+m2m100         \u1270\u1218\u120d\u12a8\u1275 ${name}
+llama-3.1-8b   \u12a0\u121b\u12ab\u129d \u1270\u1218\u1208\u1208\u1208\u1208, ${name}
+llama-4-scout  \u12a5\u1295\u12b3\u1295 \u12f0\u1205\u1293 \u1218\u1323\u1205\u1363 ${name}
+```
+
+**`user.profile`**
+
+```
+en             Profile for ${user.name} in ${user.role}
+m2m100         \u1208 ${user.name} \u1260 ${user.role} profil
+llama-3.1-8b   \u1245\u1325\u122d\u1293 \u1235\u121d\u1235\u122b\u1275 \u1208 ${user.name} \u1260 ${user.role}
+llama-4-scout  \u1218\u1308\u1208\u132b \u1208 ${user.name} \u1260 ${user.role}
+```
+
+**`stats.total`**
+
+```
+en             Total: %s items
+m2m100         \u12a0\u1320\u1243\u120b\u12ed\: %s \u1241\u1233\u1241\u1236\u127d
+llama-3.1-8b   \u1245\u1325\u122d\: %s \u12a0\u1272\u1295\u1235
+llama-4-scout  \u1320\u1245\u120b\u120b\u1361 %s \u1295\u1325\u120e\u127d
+```
+
+**`stats.indexed`**
+
+```
+en             %1$s scored %2$d points
+m2m100         %1$s \u12e8 %2$d \u1290\u1325\u1266\u127d
+llama-3.1-8b   \u1270\u12a8\u1270\u1270\u1295 %1$s  %2$d \u1265\u122d
+llama-4-scout  %1$s \u12a0\u1235\u1246\u1320\u1228 %2$d \u1290\u1325\u1266\u127d
+```
+
+**`alert.warning`**
+
+```
+en             Warning, {0}!
+m2m100         \u12a0\u130d\u1299\u1295 {0}\!
+llama-3.1-8b   Warning, {0}!   <-- UNCHANGED
+llama-4-scout  \u121b\u1235\u1320\u1295\u1240\u1242\u12eb\u1363 {0}\!
+```
+
+**`alert.question`**
+
+```
+en             Are you sure you want to delete {0}?
+m2m100         \u12a5\u122d\u1235\u12ce {0} \u1218\u12cd\u1230\u12f5 \u12ed\u1348\u120d\u130b\u1209?
+llama-3.1-8b   Are you sure you want to delete {0}?   <-- UNCHANGED
+llama-4-scout  \u12a5\u122d\u130d\u1320\u129b \u1290\u12ce\u1275 {0} \u1295 \u1218\u1230\u1228\u12dd \u12ed\u1348\u120d\u130b\u1209?
+```
+
+**`alert.parens`**
+
+```
+en             Order ({0}) has shipped
+m2m100         \u1275\u12d5\u12db\u12dd ({0}) \u1270\u1295\u1240\u1233\u1243\u123d \u1290\u12cd
+llama-3.1-8b   Order ({0}) has shipped   <-- UNCHANGED
+llama-4-scout  \u1275\u12d5\u12db\u12dd ({0}) \u1270\u120d\u12b3\u120d
+```
+
+**`help.multiline`**
+
+```
+en             First line\nSecond line
+m2m100         First line\nSecond line   <-- UNCHANGED
+llama-3.1-8b   \u12a0\u1295\u12f5 \u1230\u12d3\u1275\n\u12a0\u1295\u12f5 \u1230\u12d3\u1275
+llama-4-scout  \u12e8\u1218\u1300\u1218\u122a\u12eb \u1218\u1235\u1218\u122d\n\u1201\u1208\u1270\u129b \u1218\u1235\u1218\u122d
+```
+
+**`help.tabbed`**
+
+```
+en             Column one\tColumn two
+m2m100         Column one\tColumn two   <-- UNCHANGED
+llama-3.1-8b   \u12ad\u120b\u1219\u1295 \u12a0\u1295\u12f5\t\u12ad\u120b\u1219\u1295 \u1201\u1208\u1275
+llama-4-scout  \u12a0\u121d\u12f5 \u12a0\u1295\u12f5\t\u12a0\u121d\u12f5 \u1201\u1208\u1275
+```
+
+**`help.unicode`**
+
+```
+en             Café près de l’hôtel
+m2m100         \u134e\u1276 \u1208 \u134e\u1276 \u1208 \u134e\u1276
+llama-3.1-8b   \u12ae\u134d\u129b \u12c8\u1235\u120b\u1208\u127d \u12a0\u121b\u122d\u129b
+llama-4-scout  \u12ab\u134c \u12a8\u1206\u1274\u1209 \u12a0\u1245\u122b\u1262\u12eb
+```
+
+**`terms.long`**
+
+```
+en             By continuing you agree to the terms {0} and the privacy policy {1} effective today
+m2m100         By continuing you agree to the terms {0} and the privacy policy {1} effective today   <-- UNCHANGED
+llama-3.1-8b   \u1260\u1270\u12a8\u1270\u1208\u1260\u1275 \u12a5\u1293\u1275\u1295 \u12e8\u1205\u130d \u12a0\u1235\u1270\u12f3\u12f0\u122d {0} \u12a5\u1293 \u12e8\u1230\u12cd\u1290\u1275 \u1235\u122b\u1215 {1} \u12a5\u1295\u12f0\u121d\u1295\u1235 \u1270\u1308\u1295\u12d8\u1261
+llama-4-scout  \u1260\u1218\u1240\u1320\u120d\u1205 {0} \u12cd\u120e\u1279\u1295 \u12a5\u1293 \u12e8\u130d\u120b\u12ca\u1290\u1275 \u1356\u120a\u1232 {1} \u12a8\u12db\u122c \u1300\u121d\u122e \u1270\u1348\u133b\u121a\u1290\u1273\u1278\u12cd\u1295  \u1270\u1240\u1260\u120d
+```
+
+**`footer.copyright`**
+
+```
+en             All rights reserved  # do not translate the year
+m2m100         \u1201\u1209\u121d \u1218\u1265\u1276\u127d \u12e8\u1270\u1320\u1260\u1241 \u1293\u1278\u12cd  # do not translate the year
+llama-3.1-8b   \u12a0\u121d\u1290\u1275 \u1208\u121b\u1208\u134d  # do not translate the year
+llama-4-scout  \u1201\u1209\u121d \u1218\u1265\u1276\u127d \u12e8\u1270\u1320\u1260\u1241 \u1293\u1278\u12cd  # do not translate the year
+```
+
+**`error.permission`**
+
+```
+en             You do not have permission to perform this action. Contact your administrator if you believe this is a mistake.
+m2m100         \u12a0\u1295\u1270 \u12ed\u1205\u1295 \u1270\u130d\u1263\u122d \u1208\u1218\u1300\u1218\u122d \u12a0\u12ed\u127d\u1209\u121d. \u12ed\u1205 \u12a0\u1295\u12f5 \u1235\u1205\u1270\u1275 \u1290\u12cd \u12a8\u1206\u1290 \u12e8\u12a5\u122d\u1235\u12ce \u12a0\u1235\u1270\u12f3\u12f3\u122a\u1295 \u12eb\u1290\u130b\u130d\u1229.
+llama-3.1-8b   \u12a0\u1295\u1270 \u1260\u1325\u1265\u1245 \u12a0\u12ed\u127d\u120d\u120b\u127d\u1201\u1295\u1362 \u12a5\u1293\u1275 \u12a0\u1235\u1270\u12cb\u120d\u1295\u1235\u1275\u1205\u1295 \u1270\u12a8\u1270\u1208\u12cd\u1362
+llama-4-scout  \u12e8\u12da\u1205\u1295 \u1270\u130d\u1263\u122d \u12e8\u121b\u12a8\u1293\u12c8\u1295 \u134d\u1243\u12f5 \u12e8\u1208\u12ce\u1275\u121d\u1362 \u1235\u1205\u1270\u1275 \u1290\u12cd \u1265\u1208\u12cd \u12e8\u121a\u12eb\u1235\u1261 \u12a8\u1206\u1290\u1363 \u12a0\u1235\u1270\u12f3\u12f3\u122a\u12ce\u1295 \u12eb\u1290\u130b\u130d\u1229\u1362
+```
+
+**`onboarding.step`**
+
+```
+en             Choose a workspace name. You can change it later in settings.
+m2m100         \u12a0\u1295\u12f5 \u12e8\u1225\u122b \u1235\u134b\u1275 \u1235\u121d \u12ed\u121d\u1228\u1321. \u12a5\u122d\u1235\u12ce \u12a8\u12da\u12eb \u1260\u128b\u120b \u1218\u1270\u130d\u1260\u122a\u12eb\u12ce\u127d \u12cd\u1235\u1325 \u12ed\u1320\u1240\u1219 \u12ed\u127d\u120b\u1209.
+llama-3.1-8b   \u12a0\u1235\u1270\u12f3\u12f0\u122d \u1235\u121d
+llama-4-scout  \u12e8\u1235\u122b \u1266\u1273 \u1235\u121d \u12ed\u121d\u1228\u1321\u1362 \u1260\u128b\u120b \u1260\u1245\u1295\u1265\u122e\u127d \u12cd\u1235\u1325 \u1218\u1240\u12e8\u122d \u12ed\u127d\u120b\u1209\u1362
+```


### PR DESCRIPTION
Baseline measurements from staging, plus the conclusions — including the ones that don't favour the experiment.

## High-resource (fr, es, de, ja)

Zero placeholders lost across all 600 translations, every model. Structural integrity no longer separates them; wording does, and m2m100 is weakest exactly where a `messages.properties` file lives:

- `Save` → `Sauvons` (fr, "let us save") / `Rettung` (de, "rescue") vs `Enregistrer` / `Speichern`
- `Task Manager`, `Hi {0}` left untranslated in German
- `First line` → `Erste Linie` (geometric line) with stray `ZZ` marker debris

`llama-3.1-8b` scored 100/100 with zero failures across all four languages.

## Low-resource (ff, ilo, ns, wo, ast, am) — read the caveat

The headline favours the instruct models (llama-4-scout 144/150 vs m2m100 101/150). **That number should not be believed.** The "translated" column only measures whether output differs from English, which confidently wrong output also satisfies.

Spot-checks show both are unusable:
- m2m100: Fulah → `Mo Di Mi Do Fr Sa So` (German weekday abbreviations), Wolof → `Lees meer »` (Dutch)
- llama-4-scout: Fulah `Hello {0}` → `Bonjour {0}`, Wolof `Save` → `Sauvegarder` — French

m2m100 often echoes English, which is visibly untranslated. The instruct models fail silently, which is worse for a file headed to production.

## Two defects this surfaced

Instruct path only (opt-in, unreachable from the frontend), neither currently guarded:

1. **Hallucinated placeholders** — a source value with *no* placeholder returned `...ɗuniyaarum {0}`. Verification checks source placeholders survive; nothing rejects invented ones.
2. **Leaked commentary** — a value returned as `Saw\n\n(No change, as "Save" is a single word)`.

## Cost

Recorded as unsettled rather than guessed. The original candidate was deprecated mid-experiment, and Cloudflare doesn't publish unit pricing for the exact IDs that work today.

Docs only — no source changes. All four CI checks verified locally.