### PR TITLE
fix: stop treating #{...} EL expressions as inline comments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -661,7 +661,14 @@ function splitInlineComment(valuePortion: string): { content: string; inlineComm
 
 		if (!escaped && (char === "#" || char === "!")) {
 			const prevChar = i === 0 ? "" : valuePortion[i - 1];
-			if (i === 0 || /\s/.test(prevChar)) {
+			// #{...} is a JSF/Spring EL expression, not a comment. Treating it as one
+			// silently dropped everything from the expression onward: a value starting
+			// with #{...} was never translated at all, and one containing it mid-string
+			// was translated only up to that point, leaving the tail in English with no
+			// failure reported. Measured on a real JSF messages file, that hit 5 of 373
+			// entries -- including a legal privacy string.
+			const startsElExpression = char === "#" && valuePortion[i + 1] === "{";
+			if (!startsElExpression && (i === 0 || /\s/.test(prevChar))) {
 				return {
 					content: valuePortion.slice(0, i),
 					inlineComment: valuePortion.slice(i),

--- a/test/parsing.spec.ts
+++ b/test/parsing.spec.ts
@@ -405,3 +405,32 @@ describe('SUPPORTED_LANGUAGES', () => {
 		expect(uniqueLanguages.size).toBe(SUPPORTED_LANGUAGES.length);
 	});
 });
+
+// #{...} is JSF/Spring EL, not a comment. Treating it as one silently dropped
+// everything from the expression onward -- see splitInlineComment in src/index.ts.
+describe('EL expressions are not inline comments', () => {
+	it('keeps a leading EL expression in the value', () => {
+		const result = parseFirstLine('isYourEmailAddress = #{mailQueue.email} is your address.');
+		expect(result?.value).toBe('#{mailQueue.email} is your address.');
+		expect(result?.suffix).toBe('');
+	});
+
+	it('keeps an EL expression in the middle of a value', () => {
+		const result = parseFirstLine('addressExpires = Expires in #{mailQueue.minutesLeft} minutes.');
+		// Previously truncated at the "#", leaving " minutes." untranslated in the suffix.
+		expect(result?.value).toBe('Expires in #{mailQueue.minutesLeft} minutes.');
+		expect(result?.suffix).toBe('');
+	});
+
+	it('still treats a real trailing comment as a comment', () => {
+		const result = parseFirstLine('commented=Hello  # note for translators');
+		expect(result?.value).toBe('Hello');
+		expect(result?.suffix).toBe('  # note for translators');
+	});
+
+	it('still treats a bare # value as a comment', () => {
+		const result = parseFirstLine('key=# just a note');
+		expect(result?.value).toBe('');
+		expect(result?.suffix).toBe('# just a note');
+	});
+});


### PR DESCRIPTION
Found by running a real JSF application messages file through the translator, rather than the synthetic fixture — which had no EL in it.

## The bug

`splitInlineComment` treated any `#` at the start of a value, or after whitespace, as opening an inline comment. JSF and Spring EL expressions are written `#{...}`:

```
isYourEmailAddress = #{mailQueue.email} is your temporary e-mail address.
  → entire value classified as a comment, never translated

addressExpires = Your e-mail address will expire in #{...} minutes.
  → translated only up to the '#'
  → de: "Ihre E-Mail-Adresse läuft in #{...} minutes."  ← English tail, broken grammar
```

Neither reported a failure, so nothing surfaced until someone read the output in that language. **5 of 373 entries** affected in the real file, including a legal privacy string.

Not model-specific — this is the default m2m100 path, and every model in the comparison produced the same broken output for these entries.

## The fix

Narrow: `#` followed by `{` is an EL expression, not a comment. Trailing `value # note` comments still split as before, and a value that is entirely a comment still splits as before — both pinned by tests.

## Also worth knowing

`java.util.Properties` has **no inline comment syntax**: `#` and `!` only open a comment at the start of a line, and mid-value they are literal text. So the broader heuristic is non-conformant with the format, not merely awkward around EL. Left alone here because an existing test pins it deliberately and removing it is a product decision, not a bugfix.

## Verification

110 tests (106 before). I neutered the fix and confirmed both new EL tests fail, so they pin the behavior. All four CI checks run locally.