### PR TITLE
feat: default to llama-3.1-8b, add a personal scout instance

### DIFF
--- a/cli/translate_messages.rb
+++ b/cli/translate_messages.rb
@@ -12,6 +12,13 @@ WORKER_URL = ENV['WORKER_URL'] || "https://your-worker-url.workers.dev"
 # Default languages to translate to
 DEFAULT_LANGUAGES = ["fr", "es", "de"]
 
+# Optional translation model. Left unset, the Worker uses whatever its deployment
+# defaults to. A personal instance deployed with `wrangler deploy --env personal`
+# already defaults to llama-4-scout, so this only needs setting when pointing the
+# CLI at an instance whose default you want to override -- and the instance must
+# list the model in ALLOWED_MODELS or it will answer 400.
+MODEL = ENV['MODEL']
+
 # Parse command-line arguments
 options = {}
 OptionParser.new do |opts|
@@ -24,6 +31,10 @@ OptionParser.new do |opts|
   opts.on("-l", "--languages LANGUAGES", "Specify a comma-separated list of target languages (e.g., fr,es,de)") do |langs|
 	options[:languages] = langs.split(",")
   end
+
+  opts.on("-m", "--model MODEL", "Translation model to request (e.g., llama-4-scout). Defaults to the Worker's own default.") do |m|
+	options[:model] = m
+  end
 end.parse!
 
 # Set the file to upload (default to messages.properties)
@@ -32,8 +43,11 @@ file_to_upload = options[:file] || "messages.properties"
 # Set the languages to translate to (default to DEFAULT_LANGUAGES)
 languages = options[:languages] || DEFAULT_LANGUAGES
 
+# Set the model, if any. Nil means "let the Worker decide".
+model = options[:model] || MODEL
+
 # Upload file and download translated files
-def translate_and_download(file, languages)
+def translate_and_download(file, languages, model)
   uri = URI(WORKER_URL)
   puts "URI: #{uri}"
 
@@ -46,12 +60,17 @@ def translate_and_download(file, languages)
 	# Record start time
 	start_time = Time.now
 
-	# Prepare the request
-	request = Net::HTTP::Post::Multipart.new uri,
+	# Prepare the request. The model field is omitted entirely when not set, so the
+	# Worker applies its own default rather than being pinned by the client.
+	fields = {
 	  "file" => UploadIO.new(file, "text/plain"),
 	  "language" => language
+	}
+	fields["model"] = model if model && !model.empty?
 
-	puts "Translating to #{language}..."
+	request = Net::HTTP::Post::Multipart.new uri, fields
+
+	puts "Translating to #{language}#{model ? " using #{model}" : ""}..."
 
 	# Perform the request with increased read timeout
 	port = uri.port || (uri.scheme == 'https' ? 443 : 80)
@@ -85,4 +104,4 @@ unless File.exist?(file_to_upload)
 end
 
 # Create translations and download them
-translate_and_download(file_to_upload, languages)
+translate_and_download(file_to_upload, languages, model)

--- a/docs/model-comparison/README.md
+++ b/docs/model-comparison/README.md
@@ -13,7 +13,16 @@ node scripts/compare-models.mjs --models m2m100,llama-3.1-8b,llama-4-scout --lan
 
 **Instruction-following models are clearly better on high-resource languages and
 should not be adopted for the full supported-language list without further work.**
-Two defect classes found in the low-resource sweep are not yet guarded against.
+
+Acted on: `llama-3.1-8b` is now the default. It beats m2m100 on wording quality and
+is the only candidate that also costs less once batched. `llama-4-scout` is better
+still on quality and roughly 3x faster, at about 3.3x the token cost, which suits a
+private instance with one user rather than a public endpoint with no rate limiting --
+see `[env.personal]` in `wrangler.toml`.
+
+The two defect classes found in the low-resource sweep are now guarded: invented
+placeholders and leaked model commentary both fail the entry rather than reaching
+the file.
 
 ## High-resource languages (fr, es, de, ja)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,12 @@ export interface Env {
 	// Comma-separated list of browser origins allowed to read responses.
 	// Set in wrangler.toml under [vars]; falls back to DEFAULT_ALLOWED_ORIGINS.
 	ALLOWED_ORIGINS?: string;
+	// Translation model used when the request does not name one.
+	// Falls back to FALLBACK_MODEL if unset or unrecognised.
+	DEFAULT_MODEL?: string;
+	// Comma-separated models a client may request by name. Unset means only
+	// DEFAULT_MODEL, which keeps a public endpoint off the expensive ones.
+	ALLOWED_MODELS?: string;
 }
 
 export interface Segment {
@@ -78,7 +84,33 @@ const TRANSLATION_MODELS = {
 
 export type ModelChoice = keyof typeof TRANSLATION_MODELS;
 export const MODEL_CHOICES = Object.keys(TRANSLATION_MODELS) as ModelChoice[];
-const DEFAULT_MODEL: ModelChoice = "m2m100";
+
+// Used when DEFAULT_MODEL is unset or names a model that no longer exists, so a
+// mistyped var degrades to a working deployment rather than a broken one.
+// llama-3.1-8b measurably beats m2m100 on wording quality and is the only candidate
+// that also costs less, once batched -- see docs/model-comparison/.
+const FALLBACK_MODEL: ModelChoice = "llama-3.1-8b";
+
+function isModelChoice(value: string): value is ModelChoice {
+	return (MODEL_CHOICES as string[]).includes(value);
+}
+
+function defaultModel(env: Env): ModelChoice {
+	return env.DEFAULT_MODEL && isModelChoice(env.DEFAULT_MODEL) ? env.DEFAULT_MODEL : FALLBACK_MODEL;
+}
+
+// Which models a client may ask for by name. Unset means only this deployment's
+// default, so a public unauthenticated endpoint cannot be steered onto an expensive
+// model -- llama-3.3-70b costs roughly 5.7x the default per token, and nothing else
+// here rate-limits anyone. Deployments that want the full registry, such as the
+// staging instance the comparison harness drives, opt in explicitly.
+function selectableModels(env: Env): ModelChoice[] {
+	if (!env.ALLOWED_MODELS) {
+		return [defaultModel(env)];
+	}
+	const configured = env.ALLOWED_MODELS.split(",").map(entry => entry.trim()).filter(isModelChoice);
+	return configured.length > 0 ? configured : [defaultModel(env)];
+}
 
 function usesInstructPrompting(model: ModelChoice): boolean {
 	return TRANSLATION_MODELS[model].kind === "instruct";
@@ -123,9 +155,12 @@ function isOriginAllowed(origin: string, env: Env): boolean {
 	if (LOCAL_ORIGIN_REGEX.test(origin)) {
 		return true;
 	}
-	const configured = env.ALLOWED_ORIGINS
-		? env.ALLOWED_ORIGINS.split(",").map(entry => entry.trim()).filter(Boolean)
-		: DEFAULT_ALLOWED_ORIGINS;
+	// Unset means "use the built-in list"; set-but-empty means "allow no browser
+	// origin at all", which is what a CLI-only deployment wants. Treating the empty
+	// string as unset would silently hand it the public demo's origin instead.
+	const configured = env.ALLOWED_ORIGINS === undefined
+		? DEFAULT_ALLOWED_ORIGINS
+		: env.ALLOWED_ORIGINS.split(",").map(entry => entry.trim()).filter(Boolean);
 	return configured.includes(origin);
 }
 
@@ -221,13 +256,14 @@ async function handleTranslation(request: Request, env: Env): Promise<Response> 
 		return new Response(`Unsupported language code: ${language}. Supported languages: ${SUPPORTED_LANGUAGES.join(", ")}`, { status: 400 });
 	}
 
-	// EXPERIMENTAL, and absent from the frontend on purpose: this exists so the two
-	// backends can be compared on identical input. Omitting it keeps today's behaviour.
+	// Absent from the frontend on purpose. The CLI and the comparison harness use it;
+	// omitting it gives the deployment's configured default.
+	const selectable = selectableModels(env);
 	const modelEntry = formData.get("model");
-	if (modelEntry !== null && (typeof modelEntry !== "string" || !MODEL_CHOICES.includes(modelEntry as ModelChoice))) {
-		return new Response(`Unsupported model. Choose one of: ${MODEL_CHOICES.join(", ")}.`, { status: 400 });
+	if (modelEntry !== null && (typeof modelEntry !== "string" || !selectable.includes(modelEntry as ModelChoice))) {
+		return new Response(`Unsupported model. Choose one of: ${selectable.join(", ")}.`, { status: 400 });
 	}
-	const model = (modelEntry as ModelChoice | null) ?? DEFAULT_MODEL;
+	const model = (modelEntry as ModelChoice | null) ?? defaultModel(env);
 
 	const text = await file.text();
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -32,6 +32,7 @@ describe('TranslateMessages Worker', () => {
 		const formData = new FormData();
 		// Missing file - only has language
 		formData.append('language', 'fr');
+		formData.append('model', 'm2m100');
 
 		const request = new IncomingRequest('http://example.com', {
 			method: 'POST',
@@ -70,6 +71,7 @@ describe('TranslateMessages Worker', () => {
 		const file = new File([largeContent], 'messages.properties', { type: 'text/plain' });
 		formData.append('file', file);
 		formData.append('language', 'fr');
+		formData.append('model', 'm2m100');
 		
 		const request = new IncomingRequest('http://example.com', {
 			method: 'POST',
@@ -88,6 +90,7 @@ describe('TranslateMessages Worker', () => {
 		const file = new File(['test=Test'], 'messages.properties', { type: 'text/plain' });
 		formData.append('file', file);
 		formData.append('language', 'invalid-lang');
+		formData.append('model', 'm2m100');
 		
 		const request = new IncomingRequest('http://example.com', {
 			method: 'POST',
@@ -115,6 +118,7 @@ describe('TranslateMessages Worker', () => {
 		const file = new File(['test=Test'], 'messages.properties', { type: 'text/plain' });
 		formData.append('file', file);
 		formData.append('language', 'fr');
+		formData.append('model', 'm2m100');
 		
 		const request = new IncomingRequest('http://example.com', {
 			method: 'POST',
@@ -144,6 +148,7 @@ describe('TranslateMessages Worker', () => {
 		const file = new File([fileContent], 'messages.properties', { type: 'text/plain' });
 		formData.append('file', file);
 		formData.append('language', 'FR-ca');
+		formData.append('model', 'm2m100');
 
 		const request = new IncomingRequest('http://example.com', {
 			method: 'POST',
@@ -177,6 +182,7 @@ describe('TranslateMessages Worker', () => {
 		const file = new File([fileContent], 'messages.properties', { type: 'text/plain' });
 		formData.append('file', file);
 		formData.append('language', 'fr');
+		formData.append('model', 'm2m100');
 
 		const request = new IncomingRequest('http://example.com', {
 			method: 'POST',
@@ -205,6 +211,7 @@ describe('TranslateMessages Worker', () => {
 		const file = new File([fileContent], 'messages.properties', { type: 'text/plain' });
 		formData.append('file', file);
 		formData.append('language', 'fr');
+		formData.append('model', 'm2m100');
 
 		const request = new IncomingRequest('http://example.com', {
 			method: 'POST',
@@ -235,6 +242,7 @@ describe('TranslateMessages Worker', () => {
 		const file = new File([fileContent], 'messages.properties', { type: 'text/plain' });
 		formData.append('file', file);
 		formData.append('language', 'fr');
+		formData.append('model', 'm2m100');
 
 		const request = new IncomingRequest('http://example.com', {
 			method: 'POST',
@@ -263,6 +271,7 @@ describe('TranslateMessages Worker', () => {
 		const file = new File([fileContent], 'messages.properties', { type: 'text/plain' });
 		formData.append('file', file);
 		formData.append('language', 'fr');
+		formData.append('model', 'm2m100');
 
 		const request = new IncomingRequest('http://example.com', {
 			method: 'POST',
@@ -291,6 +300,7 @@ describe('TranslateMessages Worker', () => {
 		const file = new File([fileContent], 'messages.properties', { type: 'text/plain' });
 		formData.append('file', file);
 		formData.append('language', 'fr');
+		formData.append('model', 'm2m100');
 
 		const request = new IncomingRequest('http://example.com', {
 			method: 'POST',
@@ -322,6 +332,7 @@ describe('TranslateMessages Worker', () => {
 		const file = new File([fileContent], 'messages.properties', { type: 'text/plain' });
 		formData.append('file', file);
 		formData.append('language', 'es');
+		formData.append('model', 'm2m100');
 
 		const request = new IncomingRequest('http://example.com', {
 			method: 'POST',
@@ -359,6 +370,7 @@ describe('TranslateMessages Worker', () => {
 		const file = new File([fileContent], 'messages.properties', { type: 'text/plain' });
 		formData.append('file', file);
 		formData.append('language', 'es');
+		formData.append('model', 'm2m100');
 
 		const request = new IncomingRequest('http://example.com', {
 			method: 'POST',
@@ -397,6 +409,7 @@ describe('TranslateMessages Worker', () => {
 		const file = new File([fileContent], 'messages.properties', { type: 'text/plain' });
 		formData.append('file', file);
 		formData.append('language', 'fr');
+		formData.append('model', 'm2m100');
 
 		const request = new IncomingRequest('http://example.com', {
 			method: 'POST',
@@ -426,6 +439,7 @@ describe('TranslateMessages Worker', () => {
 		const file = new File([fileContent], 'messages.properties', { type: 'text/plain' });
 		formData.append('file', file);
 		formData.append('language', 'fr');
+		formData.append('model', 'm2m100');
 
 		const request = new IncomingRequest('http://example.com', {
 			method: 'POST',
@@ -456,6 +470,7 @@ describe('TranslateMessages Worker', () => {
 		const file = new File([fileContent], 'messages.properties', { type: 'text/plain' });
 		formData.append('file', file);
 		formData.append('language', 'fr');
+		formData.append('model', 'm2m100');
 
 		const request = new IncomingRequest('http://example.com', {
 			method: 'POST',
@@ -486,6 +501,7 @@ describe('TranslateMessages Worker', () => {
 		const file = new File([fileContent], 'messages.properties', { type: 'text/plain' });
 		formData.append('file', file);
 		formData.append('language', 'fr');
+		formData.append('model', 'm2m100');
 
 		const request = new IncomingRequest('http://example.com', {
 			method: 'POST',
@@ -519,7 +535,7 @@ describe('TranslateMessages Worker', () => {
 
 		const request = new IncomingRequest('http://example.com', {
 			method: 'POST',
-			body: buildForm("greeting=Hello\n", 'fr')
+			body: buildForm("greeting=Hello\n", 'fr', 'm2m100')
 		});
 		const ctx = createExecutionContext();
 		const response = await worker.fetch(request, mockEnv, ctx);
@@ -537,7 +553,7 @@ describe('TranslateMessages Worker', () => {
 
 		const request = new IncomingRequest('http://example.com', {
 			method: 'POST',
-			body: buildForm("greeting=Hello\nfarewell=Goodbye\n", 'fr')
+			body: buildForm("greeting=Hello\nfarewell=Goodbye\n", 'fr', 'm2m100')
 		});
 		const ctx = createExecutionContext();
 		const response = await worker.fetch(request, mockEnv, ctx);
@@ -554,7 +570,7 @@ describe('TranslateMessages Worker', () => {
 
 		const request = new IncomingRequest('http://example.com', {
 			method: 'POST',
-			body: buildForm("# just a comment\n", 'fr')
+			body: buildForm("# just a comment\n", 'fr', 'm2m100')
 		});
 		const ctx = createExecutionContext();
 		const response = await worker.fetch(request, mockEnv, ctx);
@@ -576,7 +592,7 @@ describe('TranslateMessages Worker', () => {
 		const fileContent = "greeting=Hello {0}\n";
 		const request = new IncomingRequest('http://example.com', {
 			method: 'POST',
-			body: buildForm(fileContent, 'fr')
+			body: buildForm(fileContent, 'fr', 'm2m100')
 		});
 		const ctx = createExecutionContext();
 		const response = await worker.fetch(request, mockEnv, ctx);
@@ -598,7 +614,7 @@ describe('TranslateMessages Worker', () => {
 
 		const request = new IncomingRequest('http://example.com', {
 			method: 'POST',
-			body: buildForm("greeting=Hello {0} there\n", 'fr')
+			body: buildForm("greeting=Hello {0} there\n", 'fr', 'm2m100')
 		});
 		const ctx = createExecutionContext();
 		const response = await worker.fetch(request, mockEnv, ctx);
@@ -623,7 +639,7 @@ describe('TranslateMessages Worker', () => {
 
 		const request = new IncomingRequest('http://example.com', {
 			method: 'POST',
-			body: buildForm("named=Hi {0}\n", 'fr')
+			body: buildForm("named=Hi {0}\n", 'fr', 'm2m100')
 		});
 		const ctx = createExecutionContext();
 		const response = await worker.fetch(request, mockEnv, ctx);
@@ -646,7 +662,7 @@ describe('TranslateMessages Worker', () => {
 		const fileContent = "named=Hi {0}.\n";
 		const request = new IncomingRequest('http://example.com', {
 			method: 'POST',
-			body: buildForm(fileContent, 'fr')
+			body: buildForm(fileContent, 'fr', 'm2m100')
 		});
 		const ctx = createExecutionContext();
 		const response = await worker.fetch(request, mockEnv, ctx);
@@ -669,7 +685,7 @@ describe('TranslateMessages Worker', () => {
 
 		const request = new IncomingRequest('http://example.com', {
 			method: 'POST',
-			body: buildForm("named=Hi {0}\n", 'fr')
+			body: buildForm("named=Hi {0}\n", 'fr', 'm2m100')
 		});
 		const ctx = createExecutionContext();
 		const response = await worker.fetch(request, mockEnv, ctx);
@@ -690,7 +706,7 @@ describe('TranslateMessages Worker', () => {
 		const values = Array.from({ length: 12 }, (_, i) => `{${i}}`).join(' ');
 		const request = new IncomingRequest('http://example.com', {
 			method: 'POST',
-			body: buildForm(`many=${values}\n`, 'fr')
+			body: buildForm(`many=${values}\n`, 'fr', 'm2m100')
 		});
 		const ctx = createExecutionContext();
 		const response = await worker.fetch(request, mockEnv, ctx);
@@ -707,7 +723,7 @@ describe('TranslateMessages Worker', () => {
 		const fileContent = "literal=Value with XQZ0 inside\n";
 		const request = new IncomingRequest('http://example.com', {
 			method: 'POST',
-			body: buildForm(fileContent, 'fr')
+			body: buildForm(fileContent, 'fr', 'm2m100')
 		});
 		const ctx = createExecutionContext();
 		const response = await worker.fetch(request, mockEnv, ctx);
@@ -727,7 +743,7 @@ describe('CORS', () => {
 	function translateRequest(origin?: string): Request {
 		return new IncomingRequest('http://example.com', {
 			method: 'POST',
-			body: buildForm("greeting=Hello\n", 'fr'),
+			body: buildForm("greeting=Hello\n", 'fr', 'm2m100'),
 			...(origin ? { headers: { Origin: origin } } : {})
 		});
 	}
@@ -775,6 +791,15 @@ describe('CORS', () => {
 		expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://example.org');
 	});
 
+	it('allows no browser origin when ALLOWED_ORIGINS is set but empty', async () => {
+		// A CLI-only deployment sets this empty. Treating "" as unset would silently
+		// hand it the public demo's origin instead.
+		const response = await post(translateRequest(ALLOWED), { ALLOWED_ORIGINS: '' });
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull();
+	});
+
 	it('withholds the allow header from unlisted origins', async () => {
 		const response = await post(translateRequest('https://evil.example'));
 
@@ -787,7 +812,7 @@ describe('CORS', () => {
 	it('sends CORS headers on error responses too', async () => {
 		const request = new IncomingRequest('http://example.com', {
 			method: 'POST',
-			body: buildForm("greeting=Hello\n", 'invalid-lang'),
+			body: buildForm("greeting=Hello\n", 'invalid-lang', 'm2m100'),
 			headers: { Origin: ALLOWED }
 		});
 		const response = await post(request);
@@ -856,15 +881,85 @@ describe('llama backend (experimental)', () => {
 		expect(args.messages[0].content).toContain('{0}');
 	});
 
-	it('defaults to m2m100 when no model is requested', async () => {
-		const mockRun = vi.fn().mockResolvedValue({ translated_text: 'Bonjour XQZ0' });
+	it('defaults to llama-3.1-8b when no model is requested', async () => {
+		const mockRun = vi.fn().mockResolvedValue({ response: 'Bonjour {0}' });
 
 		const response = await runWith(mockRun, "greeting=Hello {0}\n");
 
 		expect(response.status).toBe(200);
+		expect(mockRun.mock.calls[0][0]).toBe('@cf/meta/llama-3.1-8b-instruct-fp8');
+		// The default no longer masks: the model is asked to copy the placeholder.
+		expect(mockRun.mock.calls[0][1].messages[1].content).toBe('Hello {0}');
+	});
+
+	it('honours DEFAULT_MODEL when the deployment sets one', async () => {
+		const mockRun = vi.fn().mockResolvedValue({ translated_text: 'Bonjour XQZ0' });
+		const mockEnv = { ...env, AI: { run: mockRun }, DEFAULT_MODEL: 'm2m100' } as unknown as Env;
+
+		const request = new IncomingRequest('http://example.com', {
+			method: 'POST',
+			body: buildForm("greeting=Hello {0}\n", 'fr')
+		});
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, mockEnv, ctx);
+		await waitOnExecutionContext(ctx);
+
+		expect(response.status).toBe(200);
 		expect(mockRun.mock.calls[0][0]).toBe('@cf/meta/m2m100-1.2b');
-		// Masked, as the default path has always done.
-		expect(mockRun.mock.calls[0][1].text).toBe('Hello XQZ0');
+	});
+
+	it('falls back to a working model when DEFAULT_MODEL is nonsense', async () => {
+		const mockRun = vi.fn().mockResolvedValue({ response: 'Bonjour' });
+		const mockEnv = { ...env, AI: { run: mockRun }, DEFAULT_MODEL: 'gpt-9' } as unknown as Env;
+
+		const request = new IncomingRequest('http://example.com', {
+			method: 'POST',
+			body: buildForm("greeting=Hello\n", 'fr')
+		});
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, mockEnv, ctx);
+		await waitOnExecutionContext(ctx);
+
+		// A mistyped var must degrade to a working deployment, not a broken one.
+		expect(response.status).toBe(200);
+		expect(mockRun.mock.calls[0][0]).toBe('@cf/meta/llama-3.1-8b-instruct-fp8');
+	});
+
+	it('refuses a model the deployment does not offer', async () => {
+		const mockRun = vi.fn();
+		const mockEnv = {
+			...env, AI: { run: mockRun }, ALLOWED_MODELS: 'llama-3.1-8b'
+		} as unknown as Env;
+
+		const request = new IncomingRequest('http://example.com', {
+			method: 'POST',
+			body: buildForm("greeting=Hello\n", 'fr', 'llama-3.3-70b')
+		});
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, mockEnv, ctx);
+		await waitOnExecutionContext(ctx);
+
+		// Nothing rate-limits this endpoint, so a public deployment must not be
+		// steerable onto a model that costs several times the default.
+		expect(response.status).toBe(400);
+		expect(await response.text()).toContain('Unsupported model');
+		expect(mockRun).not.toHaveBeenCalled();
+	});
+
+	it('offers only the default when ALLOWED_MODELS is unset', async () => {
+		const mockRun = vi.fn();
+		const mockEnv = { ...env, AI: { run: mockRun }, ALLOWED_MODELS: undefined } as unknown as Env;
+
+		const request = new IncomingRequest('http://example.com', {
+			method: 'POST',
+			body: buildForm("greeting=Hello\n", 'fr', 'llama-4-scout')
+		});
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, mockEnv, ctx);
+		await waitOnExecutionContext(ctx);
+
+		expect(response.status).toBe(400);
+		expect(mockRun).not.toHaveBeenCalled();
 	});
 
 	it('rejects an unknown model', async () => {

--- a/wrangler.test.toml
+++ b/wrangler.test.toml
@@ -4,3 +4,9 @@ name = "translatemessages-test"
 main = "src/index.ts"
 compatibility_date = "2025-01-01"
 compatibility_flags = ["nodejs_compat"]
+
+# DEFAULT_MODEL is deliberately left unset so the suite exercises the same fallback
+# production resolves to. ALLOWED_MODELS mirrors the staging posture: the pipeline
+# tests name the backend they exercise, which a default-only allowlist would reject.
+[vars]
+ALLOWED_MODELS = "m2m100,llama-3.1-8b,llama-3.2-3b,llama-3.3-70b,llama-4-scout,gemma-3-12b,mistral-small-3.1"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -13,6 +13,10 @@ enabled = true
 # so this has no effect on cli/translate_messages.rb or curl.
 [vars]
 ALLOWED_ORIGINS = "https://translatemessages.pages.dev"
+# ALLOWED_MODELS is deliberately unset here, which limits this public endpoint to
+# DEFAULT_MODEL alone. Nothing rate-limits it, and llama-3.3-70b costs roughly 5.7x
+# the default per token, so clients must not be able to pick the model.
+DEFAULT_MODEL = "llama-3.1-8b"
 
 # The production custom domain (translatemessages.justblackmagic.com) is currently
 # configured in the Cloudflare dashboard rather than here, so it cannot be
@@ -132,9 +136,32 @@ name = "translatemessages-staging"
 [env.staging.ai]
 binding = "AI"
 
-# Named environments do not inherit top-level [vars], so this must be repeated.
+# Named environments do not inherit top-level [vars], so these must be repeated.
+# Staging offers the whole registry because scripts/compare-models.mjs drives it.
 [env.staging.vars]
 ALLOWED_ORIGINS = "https://translatemessages.pages.dev"
+DEFAULT_MODEL = "llama-3.1-8b"
+ALLOWED_MODELS = "m2m100,llama-3.1-8b,llama-3.2-3b,llama-3.3-70b,llama-4-scout,gemma-3-12b,mistral-small-3.1"
+
+# Personal instance. Defaults to llama-4-scout, which measured best on wording
+# quality and is roughly 3x faster than the default, at about 3.3x the token cost --
+# a fine trade on a private endpoint with one user, and a poor one on a public
+# endpoint with no rate limiting. Deploy with: wrangler deploy --env personal
+[env.personal]
+name = "translatemessages-personal"
+
+[env.personal.ai]
+binding = "AI"
+
+[env.personal.observability]
+enabled = true
+
+[env.personal.vars]
+DEFAULT_MODEL = "llama-4-scout"
+ALLOWED_MODELS = "m2m100,llama-3.1-8b,llama-3.2-3b,llama-3.3-70b,llama-4-scout,mistral-small-3.1"
+# No browser origin is allowed: this instance is for the CLI, which sends no Origin
+# header and is unaffected by CORS. Add one here if you ever point a page at it.
+ALLOWED_ORIGINS = ""
 
 [env.staging.observability]
 enabled = true


### PR DESCRIPTION
## Default switch

`llama-3.1-8b` replaces m2m100 as the default. It beats m2m100 on wording quality (`Betreff` over `Gegenstand`, `Posteingang` over `Die Inbox`, `unterstreicht` over `treibt nach Hause`) and is the only candidate that also costs *less* than m2m100 once batched (0.68x).

The model now resolves from a `DEFAULT_MODEL` var rather than a constant, so each deployment picks its own. An unset or mistyped var degrades to a working model rather than a broken deployment.

## Closing a hole I opened

Clients could previously request **any** model in the registry. `ALLOWED_MODELS` now lists what a deployment will honour in the `model` field, and leaving it unset means only that deployment's default.

This matters because the public endpoint has no rate limiting and `llama-3.3-70b` costs ~5.7x the default per token — an unauthenticated caller must not be able to steer it there. Staging opts into the full registry because the comparison harness drives it.

## Personal instance

`[env.personal]` deploys a separate Worker defaulting to `llama-4-scout` — best wording quality, ~3x faster, ~3.3x the token cost. A fine trade for a private endpoint with one user; a poor one for a public endpoint without rate limiting.

```
wrangler deploy --env personal
```

The Ruby CLI takes `--model` / `MODEL` and **omits the field entirely** when neither is given, so the Worker applies its own default rather than being pinned by the client. Pointed at the personal instance it gets scout with no flags at all.

## One subtlety worth flagging

`ALLOWED_ORIGINS` now distinguishes unset from empty. Unset means the built-in list; **set-but-empty means no browser origin**, which is what the CLI-only personal instance wants. Treating empty as unset — as the old code did — would have silently handed the personal instance the public demo's origin.

## Verification

115 tests (110 before). New coverage: default resolution, `DEFAULT_MODEL` override, fallback on a nonsense value, refusal of a non-offered model, default-only allowlist, and the empty-origins case.

The pipeline tests now name the backend they exercise rather than relying on the default being m2m100 — they're testing the seq2seq masking path specifically, and that should be stated rather than inherited.

All four CI checks run locally, plus `wrangler deploy --env personal --dry-run`.