### PR TITLE
feat: batch entries into one call for instruction-following models

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -316,27 +316,107 @@ async function translateMessages(text: string, targetLanguage: string, env: Env,
 	// comment-heavy file look like a total translation failure.
 	let attemptedEntries = 0;
 
-	for (let i = 0; i < entries.length; i += BATCH_SIZE) {
-		const batch = entries.slice(i, i + BATCH_SIZE);
-		const translationPromises = batch.map(async (entry) => {
-			const entryLines = entry.indexes.map((idx) => lines[idx]);
-			const { translatedLines: translatedEntryLines, failed, attempted, serviceError } = await translateEntry(entryLines, targetLanguage, env, model);
-			return { entry, translatedEntryLines, failed, attempted, serviceError };
+	const record = (entry: { indexes: number[] }, result: EntryTranslationResult) => {
+		if (result.attempted) {
+			attemptedEntries++;
+		}
+		if (result.failed) {
+			failedEntries++;
+		}
+		if (result.serviceError) {
+			serviceErrors++;
+		}
+		entry.indexes.forEach((lineIndex, idx) => {
+			translatedLines[lineIndex] = result.translatedLines[idx];
 		});
-		const batchResults = await Promise.all(translationPromises);
-		for (const { entry, translatedEntryLines, failed, attempted, serviceError } of batchResults) {
-			if (attempted) {
-				attemptedEntries++;
+	};
+
+	// An instruction-following model can translate many entries in one call, which is
+	// where the cost saving lives: the system prompt is several times the size of a
+	// typical entry, so sending it once per entry dominates the bill. A seq2seq model
+	// has no way to be told about several strings at once, so it stays one per call.
+	const units = entries.map(entry => ({
+		entry,
+		entryLines: entry.indexes.map(idx => lines[idx])
+	}));
+
+	if (usesInstructPrompting(model)) {
+		const prepared = units.map(unit => ({ ...unit, prepared: prepareEntry(unit.entryLines, model) }));
+
+		for (const unit of prepared) {
+			if (!unit.prepared) {
+				record(unit.entry, { translatedLines: unit.entryLines, failed: false, attempted: false, serviceError: false });
 			}
-			if (failed) {
-				failedEntries++;
+		}
+
+		const translatable = prepared.filter((unit): unit is typeof unit & { prepared: PreparedEntry } => unit.prepared !== null);
+		const batches: typeof translatable[] = [];
+		for (let i = 0; i < translatable.length; i += BATCH_ENTRIES) {
+			batches.push(translatable.slice(i, i + BATCH_ENTRIES));
+		}
+
+		const settled = await Promise.all(batches.map(async (batch) => {
+			let translations: Array<string | null> | null = null;
+			try {
+				translations = await translateBatch(
+					batch.map(unit => unit.prepared.combinedValue), targetLanguage, env, model
+				);
+			} catch (error) {
+				// A failed batch call is not yet a failed entry: every one of them is
+				// retried individually below, where a genuine outage becomes a service
+				// error and anything transient gets a second chance.
+				logError("batch_translation_failed", {
+					size: batch.length,
+					targetLanguage,
+					error: error instanceof Error ? error.message : String(error)
+				});
 			}
-			if (serviceError) {
-				serviceErrors++;
-			}
-			entry.indexes.forEach((lineIndex, idx) => {
-				translatedLines[lineIndex] = translatedEntryLines[idx];
+
+			return batch.map((unit, idx) => {
+				const translated = translations?.[idx] ?? null;
+				if (translated === null) {
+					return { unit, result: null };
+				}
+				const restored = verifyAndRestore(
+					translated, unit.prepared.maskedSegments, unit.prepared.unescapedValues, false
+				);
+				return { unit, result: restored };
 			});
+		}));
+
+		// Anything the batch did not account for, or returned unusably, is retried on
+		// its own. That path carries the perturbation retry and the same verification,
+		// so batching can only cost an extra call -- never a worse translation.
+		const retries: Array<{ entry: { indexes: number[] }; entryLines: string[] }> = [];
+		for (const batchResults of settled) {
+			for (const { unit, result } of batchResults) {
+				if (result) {
+					record(unit.entry, {
+						translatedLines: assembleEntry(unit.prepared, result),
+						failed: false,
+						attempted: true,
+						serviceError: false
+					});
+				} else {
+					retries.push({ entry: unit.entry, entryLines: unit.entryLines });
+				}
+			}
+		}
+
+		for (let i = 0; i < retries.length; i += BATCH_SIZE) {
+			const slice = retries.slice(i, i + BATCH_SIZE);
+			const results = await Promise.all(
+				slice.map(unit => translateEntry(unit.entryLines, targetLanguage, env, model))
+			);
+			results.forEach((result, idx) => record(slice[idx].entry, result));
+		}
+	} else {
+		for (let i = 0; i < units.length; i += BATCH_SIZE) {
+			const slice = units.slice(i, i + BATCH_SIZE);
+			const results = await Promise.all(
+				slice.map(unit => translateEntry(unit.entryLines, targetLanguage, env, model))
+			);
+			results.forEach((result, idx) => record(slice[idx].entry, result));
 		}
 	}
 
@@ -395,6 +475,86 @@ async function translateWithInstructModel(
 	) as { response?: string };
 
 	return cleanInstructOutput(response.response ?? "");
+}
+
+// Entries per batched call. The system prompt is ~105 tokens against ~24 tokens for
+// a typical entry, so batching is almost entirely about amortising the prompt: 20
+// per call already captures nearly all of the saving that 50 would, and a smaller
+// batch means a mis-formatted reply costs less to redo.
+const BATCH_ENTRIES = 20;
+
+// A batched reply must arrive as "<n>. <translation>" per line, one line per entry
+// sent. Anything else and the batch is discarded and its entries retried singly,
+// which is why a loose parse here would be worse than none.
+const NUMBERED_LINE_REGEX = /^\s*(\d+)\s*[.):]\s?(.*)$/;
+
+function batchSystemPrompt(targetLanguage: string, count: number): string {
+	const languageName = describeLanguage(targetLanguage);
+	return [
+		`You translate strings from a Java .properties file from English into ${languageName}.`,
+		"",
+		`You are given ${count} numbered strings. Reply with exactly ${count} lines.`,
+		"Each line must be the number, a period, a space, then the translation.",
+		"",
+		"Rules:",
+		"- Reply with the numbered translations only. No preamble, no explanation, no notes.",
+		"- Keep one translation per line. Never merge or split lines, never renumber.",
+		"- Copy every placeholder exactly as written, including {0}, {1}, ${name}, %s and %d.",
+		`- Copy any ${SEGMENT_DELIMITER} token exactly; it separates parts of one string.`,
+		`- Copy any ${PLACEHOLDER_MARKER_PREFIX} token followed by digits exactly.`,
+		"- Translate the wording only. Do not add, drop or reorder content."
+	].join("\n");
+}
+
+// Translates several entries in one call. Returns a translation per input, or null
+// for an entry the reply did not cleanly account for; the caller retries those
+// singly rather than guessing. Returns null outright if the reply is unusable.
+async function translateBatch(
+	values: string[],
+	targetLanguage: string,
+	env: Env,
+	model: ModelChoice
+): Promise<Array<string | null> | null> {
+	const numbered = values.map((value, idx) => `${idx + 1}. ${value}`).join("\n");
+
+	const response = await env.AI.run(
+		TRANSLATION_MODELS[model].id,
+		{
+			messages: [
+				{ role: "system", content: batchSystemPrompt(targetLanguage, values.length) },
+				{ role: "user", content: numbered }
+			],
+			temperature: 0,
+			max_tokens: 4096
+		} as never
+	) as { response?: string };
+
+	const reply = (response.response ?? "").trim();
+	if (!reply) {
+		return null;
+	}
+
+	// Indexed by the number the model echoed back, not by line position: a model that
+	// drops line 7 must not silently shift every translation after it up by one.
+	const byIndex = new Map<number, string>();
+	for (const line of reply.split(/\r?\n/)) {
+		const match = line.match(NUMBERED_LINE_REGEX);
+		if (!match) {
+			continue;
+		}
+		const index = Number(match[1]);
+		// First occurrence wins; a repeated number means the reply is confused about
+		// the mapping, so trusting the later one would be arbitrary.
+		if (index >= 1 && index <= values.length && !byIndex.has(index)) {
+			byIndex.set(index, match[2].trim());
+		}
+	}
+
+	if (byIndex.size === 0) {
+		return null;
+	}
+
+	return values.map((_, idx) => byIndex.get(idx + 1) ?? null);
 }
 
 function instructSystemPrompt(targetLanguage: string): string {
@@ -462,6 +622,17 @@ async function translateSegments(
 	env: Env
 ): Promise<string[] | null> {
 	const translatedCombined = await translateText(combinedValue, targetLanguage, env, model);
+	return verifyAndRestore(translatedCombined, maskedSegments, sourceValues, stripTrailingTerminator);
+}
+
+// The half of an attempt that does not talk to the model, split out so a batched
+// call can apply exactly the same checks per entry as a single call does.
+function verifyAndRestore(
+	translatedCombined: string,
+	maskedSegments: MaskedSegment[],
+	sourceValues: string[],
+	stripTrailingTerminator: boolean
+): string[] | null {
 	const translatedSegments = translatedCombined.split(SEGMENT_DELIMITER).map(normalizeMarkers);
 
 	if (translatedSegments.length !== maskedSegments.length) {
@@ -535,30 +706,42 @@ interface EntryTranslationResult {
 	serviceError: boolean;
 }
 
-async function translateEntry(lines: string[], targetLanguage: string, env: Env, model: ModelChoice): Promise<EntryTranslationResult> {
+// Everything an entry needs before anyone talks to a model. Split out so a batched
+// call and a single call share exactly one notion of what is translatable and how it
+// is masked -- two notions would drift.
+interface PreparedEntry {
+	lines: string[];
+	segments: Segment[];
+	maskedSegments: MaskedSegment[];
+	unescapedValues: string[];
+	combinedValue: string;
+}
+
+// Null when the entry is not translatable at all: a comment, a blank, an unparseable
+// line, an empty value, or one carrying text that collides with an internal marker.
+function prepareEntry(lines: string[], model: ModelChoice): PreparedEntry | null {
 	const firstLine = lines[0];
 	const trimmedFirstLine = firstLine.trim();
 
 	if (!trimmedFirstLine || trimmedFirstLine.startsWith("#") || trimmedFirstLine.startsWith("!")) {
-		return { translatedLines: lines, failed: false, attempted: false, serviceError: false };
+		return null;
 	}
 
 	const segments: Segment[] = [];
 	const firstSegment = parseFirstLine(firstLine);
 	if (!firstSegment) {
-		return { translatedLines: lines, failed: false, attempted: false, serviceError: false };
+		return null;
 	}
 	segments.push(firstSegment);
 
 	for (let i = 1; i < lines.length; i++) {
-		const segment = parseContinuationLine(lines[i]);
-		segments.push(segment);
+		segments.push(parseContinuationLine(lines[i]));
 	}
 
 	const unescapedValues = segments.map(segment => unescapePropertiesText(segment.value));
 
 	if (unescapedValues.every(value => value === "")) {
-		return { translatedLines: lines, failed: false, attempted: false, serviceError: false };
+		return null;
 	}
 
 	// Source text containing either internal marker would survive the round trip and
@@ -567,7 +750,7 @@ async function translateEntry(lines: string[], targetLanguage: string, env: Env,
 	// restorePlaceholders into whatever placeholder happened to take that index.
 	// Leaving such entries untranslated is the safe outcome.
 	if (unescapedValues.some(value => value.includes(SEGMENT_DELIMITER) || value.includes(PLACEHOLDER_MARKER_PREFIX))) {
-		return { translatedLines: lines, failed: false, attempted: false, serviceError: false };
+		return null;
 	}
 
 	const placeholderCounter = { current: 0 };
@@ -576,6 +759,23 @@ async function translateEntry(lines: string[], targetLanguage: string, env: Env,
 	// left that word untranslated. Continuation values already end with a space
 	// before their backslash, so the left-hand side needs no padding.
 	const combinedValue = maskedSegments.map(segment => segment.text).join(`${SEGMENT_DELIMITER} `);
+
+	return { lines, segments, maskedSegments, unescapedValues, combinedValue };
+}
+
+function assembleEntry(prepared: PreparedEntry, restoredValues: string[]): string[] {
+	return prepared.segments.map((segment, idx) =>
+		`${segment.prefix}${escapePropertiesText(restoredValues[idx])}${segment.suffix}`
+	);
+}
+
+async function translateEntry(lines: string[], targetLanguage: string, env: Env, model: ModelChoice): Promise<EntryTranslationResult> {
+	const prepared = prepareEntry(lines, model);
+	if (!prepared) {
+		return { translatedLines: lines, failed: false, attempted: false, serviceError: false };
+	}
+	const { segments, maskedSegments, unescapedValues, combinedValue } = prepared;
+	const firstLine = lines[0];
 
 	try {
 		let restoredValues = await translateSegments(
@@ -600,11 +800,7 @@ async function translateEntry(lines: string[], targetLanguage: string, env: Env,
 			return { translatedLines: lines, failed: true, attempted: true, serviceError: false };
 		}
 
-		const translatedLines = segments.map((segment, idx) => {
-			const escapedValue = escapePropertiesText(restoredValues[idx]);
-			return `${segment.prefix}${escapedValue}${segment.suffix}`;
-		});
-		return { translatedLines, failed: false, attempted: true, serviceError: false };
+		return { translatedLines: assembleEntry(prepared, restoredValues), failed: false, attempted: true, serviceError: false };
 	} catch (error) {
 		logError("entry_translation_failed", {
 			entryKey: firstLine.split(/[=:\s]/)[0]?.trim() || "unknown",

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -867,7 +867,7 @@ describe('llama backend (experimental)', () => {
 	}
 
 	it('sends placeholders unmasked and keeps them in the output', async () => {
-		const mockRun = vi.fn().mockResolvedValue({ response: 'Bonjour {0}' });
+		const mockRun = vi.fn().mockResolvedValue({ response: '1. Bonjour {0}' });
 
 		const response = await runWith(mockRun, "greeting=Hello {0}\n", 'llama-3.1-8b');
 
@@ -877,19 +877,19 @@ describe('llama backend (experimental)', () => {
 		const [modelId, args] = mockRun.mock.calls[0];
 		expect(modelId).toBe('@cf/meta/llama-3.1-8b-instruct-fp8');
 		// The whole hypothesis: the model sees the real placeholder, not a marker.
-		expect(args.messages[1].content).toBe('Hello {0}');
+		expect(args.messages[1].content).toBe('1. Hello {0}');
 		expect(args.messages[0].content).toContain('{0}');
 	});
 
 	it('defaults to llama-3.1-8b when no model is requested', async () => {
-		const mockRun = vi.fn().mockResolvedValue({ response: 'Bonjour {0}' });
+		const mockRun = vi.fn().mockResolvedValue({ response: '1. Bonjour {0}' });
 
 		const response = await runWith(mockRun, "greeting=Hello {0}\n");
 
 		expect(response.status).toBe(200);
 		expect(mockRun.mock.calls[0][0]).toBe('@cf/meta/llama-3.1-8b-instruct-fp8');
 		// The default no longer masks: the model is asked to copy the placeholder.
-		expect(mockRun.mock.calls[0][1].messages[1].content).toBe('Hello {0}');
+		expect(mockRun.mock.calls[0][1].messages[1].content).toBe('1. Hello {0}');
 	});
 
 	it('honours DEFAULT_MODEL when the deployment sets one', async () => {
@@ -1042,5 +1042,107 @@ describe('llama backend (experimental)', () => {
 		const response = await runWith(mockRun, "greeting=He said \"hello\" {0}\n", 'llama-3.1-8b');
 
 		expect(await response.text()).toBe("greeting=Il a dit \"bonjour\" {0}\n");
+	});
+});
+
+// Batching is where the cost saving lives: the system prompt is several times the
+// size of a typical entry, so sending it once per entry dominates the bill.
+describe('batched translation', () => {
+	function runBatched(mockRun: ReturnType<typeof vi.fn>, content: string) {
+		const mockEnv = { ...env, AI: { run: mockRun } } as unknown as Env;
+		const request = new IncomingRequest('http://example.com', {
+			method: 'POST',
+			body: buildForm(content, 'fr', 'llama-3.1-8b')
+		});
+		const ctx = createExecutionContext();
+		return worker.fetch(request, mockEnv, ctx).then(async (response) => {
+			await waitOnExecutionContext(ctx);
+			return response;
+		});
+	}
+
+	const THREE = "a=One\nb=Two\nc=Three\n";
+
+	it('translates several entries in a single call', async () => {
+		const mockRun = vi.fn().mockResolvedValue({ response: '1. Un\n2. Deux\n3. Trois' });
+
+		const response = await runBatched(mockRun, THREE);
+
+		expect(await response.text()).toBe("a=Un\nb=Deux\nc=Trois\n");
+		expect(mockRun).toHaveBeenCalledTimes(1);
+		expect(mockRun.mock.calls[0][1].messages[1].content).toBe('1. One\n2. Two\n3. Three');
+	});
+
+	it('maps translations by the number the model returned, not by position', async () => {
+		// A model that drops line 2 must not shift line 3 up into its place.
+		const mockRun = vi.fn()
+			.mockResolvedValueOnce({ response: '1. Un\n3. Trois' })
+			.mockResolvedValue({ response: 'Deux' });
+
+		const response = await runBatched(mockRun, THREE);
+
+		expect(await response.text()).toBe("a=Un\nb=Deux\nc=Trois\n");
+		// Only the missing entry is retried, not the whole batch.
+		expect(mockRun).toHaveBeenCalledTimes(2);
+	});
+
+	it('retries entries individually when the batch reply is unusable', async () => {
+		const mockRun = vi.fn()
+			.mockResolvedValueOnce({ response: 'I am afraid I cannot help with that.' })
+			.mockResolvedValue({ response: 'Traduit' });
+
+		const response = await runBatched(mockRun, THREE);
+
+		// Batch discarded, three singles: never a worse translation, only an extra call.
+		expect(await response.text()).toBe("a=Traduit\nb=Traduit\nc=Traduit\n");
+		expect(mockRun).toHaveBeenCalledTimes(4);
+	});
+
+	it('falls back to singles when the batch call throws', async () => {
+		const mockRun = vi.fn()
+			.mockRejectedValueOnce(new Error('AI service blip'))
+			.mockResolvedValue({ response: 'Traduit' });
+
+		const response = await runBatched(mockRun, THREE);
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("a=Traduit\nb=Traduit\nc=Traduit\n");
+		expect(response.headers.get('X-Translation-Failures')).toBeNull();
+	});
+
+	it('still reports 500 when every entry fails at the API', async () => {
+		const mockRun = vi.fn().mockRejectedValue(new Error('AI service unavailable'));
+
+		const response = await runBatched(mockRun, THREE);
+
+		expect(response.status).toBe(500);
+	});
+
+	it('applies placeholder verification to batched results', async () => {
+		// The guard must not be reachable only through the single-entry path.
+		const mockRun = vi.fn()
+			.mockResolvedValueOnce({ response: '1. Bonjour {0} et {0}' })
+			.mockResolvedValue({ response: 'Bonjour {0} et {0}' });
+
+		const response = await runBatched(mockRun, "greeting=Hello {0}\n");
+
+		expect(await response.text()).toBe("greeting=Hello {0}\n");
+		expect(response.headers.get('X-Translation-Failures')).toBe('1');
+	});
+
+	it('does not batch a seq2seq model, which cannot be told about several strings', async () => {
+		const mockRun = vi.fn().mockResolvedValue({ translated_text: 'Traduit' });
+		const mockEnv = { ...env, AI: { run: mockRun } } as unknown as Env;
+		const request = new IncomingRequest('http://example.com', {
+			method: 'POST',
+			body: buildForm(THREE, 'fr', 'm2m100')
+		});
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, mockEnv, ctx);
+		await waitOnExecutionContext(ctx);
+
+		expect(response.status).toBe(200);
+		expect(mockRun).toHaveBeenCalledTimes(3);
+		expect(mockRun.mock.calls[0][1].text).toBe('One');
 	});
 });


### PR DESCRIPTION
The cost case for `llama-3.1-8b` depended on batching, which didn't exist yet. Unbatched it's ~1.57x m2m100; batched ~0.70x. The system prompt is ~105 tokens against ~24 for a typical entry, so sending it once per entry dominated the bill.

## What changed

Instruct models translate up to **20 entries per call**. Twenty captures nearly all the saving fifty would, and a smaller batch means a mis-formatted reply costs less to redo. Seq2seq is untouched — m2m100 can't be told about several strings at once, so it stays one call per entry.

**Replies are mapped by the number the model echoed back, not by line position.** A model that drops line 7 must not silently shift every later translation up by one — there's a test for exactly that. A repeated number means the reply is confused about the mapping, so the first occurrence wins rather than arbitrarily preferring the later one.

**Batching can cost an extra call but never a worse translation.** Anything the batch doesn't account for — a missing line, an unparseable reply, a call that throws — is retried on the existing single-entry path, which carries the perturbation retry and identical verification. A batch call that throws isn't yet a failed entry; only the individual retry can mark a service error, so a transient blip can't produce a spurious 500.

Verification is unchanged and applies identically to batched results: markers must survive, placeholders must not be invented or duplicated, commentary is stripped. There's a test asserting the placeholder guard is reachable through the batched path, not just the single one.

Preparation and assembly were split out of `translateEntry` so both paths share exactly one notion of what's translatable and how it's masked, rather than two that drift.

## Verification

122 tests (115 before). New: single-call batching, number-based mapping when a line is dropped, fallback on unusable reply, fallback when the call throws, 500 still reported on total API failure, placeholder verification through the batched path, and seq2seq not batching.

All four CI checks run locally.