### PR TITLE
feat: rate limit the public endpoint per client IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,31 @@ allowed, so `local.html` and `npm run dev` need no configuration.
 This affects browsers only — the Ruby CLI and `curl` send no `Origin` header and are
 unaffected by this setting.
 
+### Rate Limiting
+
+The Worker binds Cloudflare's rate limiting API per client IP. Configure it in
+`wrangler.toml`:
+
+```toml
+[[ratelimits]]
+name = "RATE_LIMITER"
+namespace_id = "1001"
+
+  [ratelimits.simple]
+  limit = 20
+  period = 60      # the runtime accepts only 10 or 60
+```
+
+Omit the binding entirely and no limiting happens, which is what a private
+single-user deployment wants. A limiter that errors fails open — a broken limiter is
+not a reason to refuse translations.
+
+**This is burst protection, not a spending cap.** The window maxes out at 60 seconds
+and the counters are per Cloudflare location rather than global, so a client spread
+across locations gets proportionally more than the configured limit. Capping a day's
+spend needs a durable counter (KV, D1 or a Durable Object) keyed by date, or
+account-level billing controls.
+
 ### Deploying to Cloudflare Pages
 
 Once you have edited the `index.html` file, you can deploy the `pages` directory as a Cloudflare Pages application.

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,9 @@ export interface Env {
 	// Comma-separated models a client may request by name. Unset means only
 	// DEFAULT_MODEL, which keeps a public endpoint off the expensive ones.
 	ALLOWED_MODELS?: string;
+	// Optional per-IP burst limiter. Absent means no limiting, which is what a private
+	// single-user deployment wants; the public deployments bind it in wrangler.toml.
+	RATE_LIMITER?: RateLimit;
 }
 
 export interface Segment {
@@ -178,6 +181,39 @@ function corsHeaders(request: Request, env: Env): Record<string, string> {
 	return headers;
 }
 
+// Must match simple.period in the [[ratelimits]] binding, which the runtime only
+// accepts as 10 or 60. It is reported to the caller as Retry-After.
+const RATE_LIMIT_PERIOD_SECONDS = 60;
+
+// CF-Connecting-IP is set by the edge and cannot be spoofed by the client. The
+// fallback only matters off Cloudflare -- in tests and `wrangler dev` -- where it
+// buckets everyone together, which is fine because no limiter is bound there either.
+function clientKey(request: Request): string {
+	return request.headers.get("CF-Connecting-IP") ?? "unknown";
+}
+
+// Burst protection only. The binding's window maxes out at 60 seconds, so this stops
+// a script hammering the endpoint; it does not cap daily spend, and the counters are
+// per Cloudflare location rather than global, so a client spread across locations
+// gets proportionally more. Capping a day's spend needs a durable counter, not this.
+async function isRateLimited(request: Request, env: Env): Promise<boolean> {
+	if (!env.RATE_LIMITER) {
+		return false;
+	}
+
+	try {
+		const { success } = await env.RATE_LIMITER.limit({ key: clientKey(request) });
+		return !success;
+	} catch (error) {
+		// A limiter that is failing is not a reason to refuse translations. Log it and
+		// let the request through rather than turning an internal fault into an outage.
+		logError("rate_limiter_error", {
+			error: error instanceof Error ? error.message : String(error)
+		});
+		return false;
+	}
+}
+
 // Structured logging helper for better observability
 function logError(event: string, details: Record<string, unknown>): void {
 	console.error(JSON.stringify({
@@ -205,6 +241,17 @@ export default {
 					"Access-Control-Max-Age": "86400"
 				}
 			});
+		}
+
+		// Checked after the preflight branch on purpose: rate-limiting an OPTIONS
+		// request would make the browser report a CORS failure rather than the 429 the
+		// user should see.
+		if (await isRateLimited(request, env)) {
+			logError("rate_limited", { ip: clientKey(request) });
+			return new Response(
+				"Too many requests. Please wait a minute and try again.",
+				{ status: 429, headers: { ...cors, "Retry-After": String(RATE_LIMIT_PERIOD_SECONDS) } }
+			);
 		}
 
 		// Applied to every response, including errors: without the allow header the

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1146,3 +1146,109 @@ describe('batched translation', () => {
 		expect(mockRun.mock.calls[0][1].text).toBe('One');
 	});
 });
+
+// Burst protection for the public endpoint. The binding is optional: a deployment
+// without it does no limiting, which is what the single-user personal instance wants.
+describe('rate limiting', () => {
+	function limiterEnv(limit: ReturnType<typeof vi.fn>, aiRun?: ReturnType<typeof vi.fn>) {
+		return {
+			...env,
+			AI: { run: aiRun ?? vi.fn().mockResolvedValue({ response: '1. Bonjour' }) },
+			RATE_LIMITER: { limit }
+		} as unknown as Env;
+	}
+
+	function translateRequest(ip = '203.0.113.7') {
+		return new IncomingRequest('http://example.com', {
+			method: 'POST',
+			body: buildForm("greeting=Hello\n", 'fr'),
+			headers: { 'CF-Connecting-IP': ip, Origin: 'https://translatemessages.pages.dev' }
+		});
+	}
+
+	async function send(request: Request, mockEnv: Env) {
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, mockEnv, ctx);
+		await waitOnExecutionContext(ctx);
+		return response;
+	}
+
+	it('rejects with 429 once the limit is exceeded', async () => {
+		const limit = vi.fn().mockResolvedValue({ success: false });
+		const aiRun = vi.fn();
+
+		const response = await send(translateRequest(), limiterEnv(limit, aiRun));
+
+		expect(response.status).toBe(429);
+		expect(response.headers.get('Retry-After')).toBe('60');
+		// No AI call: the point is to not spend the budget on a refused request.
+		expect(aiRun).not.toHaveBeenCalled();
+	});
+
+	it('keeps CORS headers on the 429', async () => {
+		const limit = vi.fn().mockResolvedValue({ success: false });
+
+		const response = await send(translateRequest(), limiterEnv(limit));
+
+		// Asserted together: a 200 carries the same header, so checking the header
+		// alone would pass even if the limiter were bypassed entirely.
+		expect(response.status).toBe(429);
+		// Without these the browser discards the body and the frontend shows a generic
+		// network error instead of "you are being rate limited".
+		expect(response.headers.get('Access-Control-Allow-Origin'))
+			.toBe('https://translatemessages.pages.dev');
+		expect(await response.text()).toContain('Too many requests');
+	});
+
+	it('buckets by client IP', async () => {
+		const limit = vi.fn().mockResolvedValue({ success: true });
+
+		await send(translateRequest('198.51.100.4'), limiterEnv(limit));
+
+		expect(limit).toHaveBeenCalledWith({ key: '198.51.100.4' });
+	});
+
+	it('lets the request through when under the limit', async () => {
+		const limit = vi.fn().mockResolvedValue({ success: true });
+
+		const response = await send(translateRequest(), limiterEnv(limit));
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("greeting=Bonjour\n");
+	});
+
+	it('does not limit preflight requests', async () => {
+		const limit = vi.fn().mockResolvedValue({ success: false });
+		const request = new IncomingRequest('http://example.com', {
+			method: 'OPTIONS',
+			headers: { Origin: 'https://translatemessages.pages.dev', 'CF-Connecting-IP': '203.0.113.7' }
+		});
+
+		const response = await send(request, limiterEnv(limit));
+
+		// Limiting the preflight would surface as a CORS failure rather than the 429
+		// the user should actually see.
+		expect(response.status).toBe(204);
+		expect(limit).not.toHaveBeenCalled();
+	});
+
+	it('fails open when the limiter itself errors', async () => {
+		const limit = vi.fn().mockRejectedValue(new Error('limiter unavailable'));
+
+		const response = await send(translateRequest(), limiterEnv(limit));
+
+		// A broken limiter is not a reason to refuse translations.
+		expect(response.status).toBe(200);
+	});
+
+	it('does no limiting when no limiter is bound', async () => {
+		const mockEnv = {
+			...env,
+			AI: { run: vi.fn().mockResolvedValue({ response: '1. Bonjour' }) }
+		} as unknown as Env;
+
+		const response = await send(translateRequest(), mockEnv);
+
+		expect(response.status).toBe(200);
+	});
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -18,6 +18,18 @@ ALLOWED_ORIGINS = "https://translatemessages.pages.dev"
 # the default per token, so clients must not be able to pick the model.
 DEFAULT_MODEL = "llama-3.1-8b"
 
+# Per-IP burst protection for the public endpoint. Burst only: the binding's window
+# maxes out at 60 seconds and its counters are per Cloudflare location, so this stops
+# a script hammering the endpoint but does not cap a day's spend. 20/minute leaves
+# room for the CLI translating into a dozen languages back to back.
+[[ratelimits]]
+name = "RATE_LIMITER"
+namespace_id = "1001"
+
+  [ratelimits.simple]
+  limit = 20
+  period = 60
+
 # The production custom domain (translatemessages.justblackmagic.com) is currently
 # configured in the Cloudflare dashboard rather than here, so it cannot be
 # reproduced from this repo alone. To make it declarative, uncomment:
@@ -136,12 +148,25 @@ name = "translatemessages-staging"
 [env.staging.ai]
 binding = "AI"
 
+[env.staging.observability]
+enabled = true
+
 # Named environments do not inherit top-level [vars], so these must be repeated.
 # Staging offers the whole registry because scripts/compare-models.mjs drives it.
 [env.staging.vars]
 ALLOWED_ORIGINS = "https://translatemessages.pages.dev"
 DEFAULT_MODEL = "llama-3.1-8b"
 ALLOWED_MODELS = "m2m100,llama-3.1-8b,llama-3.2-3b,llama-3.3-70b,llama-4-scout,gemma-3-12b,mistral-small-3.1"
+
+# A separate namespace from production, so the comparison harness hitting staging
+# hard cannot consume production's budget for the same IP.
+[[env.staging.ratelimits]]
+name = "RATE_LIMITER"
+namespace_id = "1002"
+
+  [env.staging.ratelimits.simple]
+  limit = 60
+  period = 60
 
 # Personal instance. Defaults to llama-4-scout, which measured best on wording
 # quality and is roughly 3x faster than the default, at about 3.3x the token cost --
@@ -162,6 +187,5 @@ ALLOWED_MODELS = "m2m100,llama-3.1-8b,llama-3.2-3b,llama-3.3-70b,llama-4-scout,m
 # No browser origin is allowed: this instance is for the CLI, which sends no Origin
 # header and is unaffected by CORS. Add one here if you ever point a page at it.
 ALLOWED_ORIGINS = ""
-
-[env.staging.observability]
-enabled = true
+# Deliberately no [[ratelimits]] binding: one known user, and the code treats a
+# missing binding as "do not limit". Add one if this URL ever gets shared.


### PR DESCRIPTION
The last outstanding item from the original review. The endpoint is unauthenticated and spends Workers AI budget, and nothing stopped a script consuming all of it.

## What it does

Buckets by `CF-Connecting-IP` — set by the edge, not spoofable by the client.

- **Production**: 20/minute. Leaves room for the CLI translating into a dozen languages back to back.
- **Staging**: 60/minute on a *separate namespace*, so the comparison harness can't consume production's budget for the same IP.
- **Personal instance**: no binding at all. The code treats a missing binding as "do not limit", which is what a single-user deployment wants.

A limiter that throws **fails open** and logs — a broken limiter isn't a reason to refuse translations.

The check sits *after* the preflight branch deliberately: rate-limiting an `OPTIONS` request would surface in the browser as a CORS failure rather than the 429 the user should see. The 429 carries CORS headers and `Retry-After`, so the frontend can show the real reason.

## What it does not do

**This is burst protection, not a spending cap.** Two limits are worth stating plainly:

- The binding's window maxes out at **60 seconds**, so 20/min sustained is ~28k requests/day — far more than the free allocation.
- Counters are **per Cloudflare location**, not global, so a client spread across locations gets proportionally more than the configured limit.

Capping a day's spend needs a durable counter (KV/D1/DO) keyed by date, or account-level billing controls. That's a separate piece of work — say the word if you want it.

## Verification

129 tests (122 before): 429 on limit, CORS + Retry-After on the 429, IP bucketing, pass-through under the limit, preflight exempt, fail-open on limiter error, and no limiting when unbound.

Mutation-tested — and it caught that my CORS-on-429 test would have passed even with the limiter bypassed, since a 200 carries the same header. Tightened to assert status and body too.

`wrangler --dry-run` confirms the binding resolves on production and staging and is absent on personal.